### PR TITLE
[Feat] 공유하기 구현 (#42)

### DIFF
--- a/WAL/WAL/Global/Extension/UIView+.swift
+++ b/WAL/WAL/Global/Extension/UIView+.swift
@@ -23,4 +23,15 @@ extension UIView {
     func addSubviews(_ views: [UIView]) {
         views.forEach { self.addSubview($0) }
     }
+    
+    func toImage() -> UIImage {
+        UIGraphicsBeginImageContextWithOptions(frame.size, false, UIScreen.main.scale)
+        
+        drawHierarchy(in: self.bounds, afterScreenUpdates: true)
+        
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return image!
+    }
 }

--- a/WAL/WAL/Resource/Support/SceneDelegate.swift
+++ b/WAL/WAL/Resource/Support/SceneDelegate.swift
@@ -54,6 +54,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
+        NotificationCenter.default.post(name: NSNotification.Name("EnterMain"), object: nil)
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {

--- a/WAL/WAL/Screen/Main/Controller/MainViewController.swift
+++ b/WAL/WAL/Screen/Main/Controller/MainViewController.swift
@@ -150,6 +150,7 @@ final class MainViewController: UIViewController {
         super.viewWillAppear(animated)
         configNavigationUI()
         checkTime()
+        print(#function)
     }
     
     override func viewDidLoad() {
@@ -279,32 +280,58 @@ final class MainViewController: UIViewController {
     }
     
     @objc func touchupShareButton() {
-        if let storyShareURL = URL(string: "instagram-stories://share") {
-            if UIApplication.shared.canOpenURL(storyShareURL) {
-                let renderer = UIGraphicsImageRenderer(size: walContentView.bounds.size)
-                
-                let renderImage = renderer.image { _ in
-                    walContentView.drawHierarchy(in: walContentView.bounds, afterScreenUpdates: true)
-                }
+//        if let storyShareURL = URL(string: "instagram-stories://share") {
+//            if UIApplication.shared.canOpenURL(storyShareURL) {
+//                let renderer = UIGraphicsImageRenderer(size: walContentView.bounds.size)
+//
+//                let renderImage = renderer.image { _ in
+//                    walContentView.drawHierarchy(in: walContentView.bounds, afterScreenUpdates: true)
+//                }
+//
+//                guard let imageData = renderImage.pngData() else { return }
+//
+//                let pasteboardItems : [String:Any] = [
+//                    "com.instagram.sharedSticker.stickerImage": imageData,
+//                    "com.instagram.sharedSticker.backgroundTopColor" : "#ffffff",
+//                    "com.instagram.sharedSticker.backgroundBottomColor" : "#ffffff",
+//                ]
+//
+//                let pasteboardOptions = [
+//                    UIPasteboard.OptionsKey.expirationDate : Date().addingTimeInterval(300)
+//                ]
+//
+//                UIPasteboard.general.setItems([pasteboardItems], options: pasteboardOptions)
+//
+//                UIApplication.shared.open(storyShareURL, options: [:], completionHandler: nil)
+//            } else {
+//                print("인스타 앱이 깔려있지 않습니다.")
+//            }
+//        }
+        
+        let imageToShare = walContentView.toImage()
 
-                guard let imageData = renderImage.pngData() else { return }
-                
-                let pasteboardItems : [String:Any] = [
-                    "com.instagram.sharedSticker.stickerImage": imageData,
-                    "com.instagram.sharedSticker.backgroundTopColor" : "#ffffff",
-                    "com.instagram.sharedSticker.backgroundBottomColor" : "#ffffff",
-                ]
-                
-                let pasteboardOptions = [
-                    UIPasteboard.OptionsKey.expirationDate : Date().addingTimeInterval(300)
-                ]
-                
-                UIPasteboard.general.setItems([pasteboardItems], options: pasteboardOptions)
-                
-                UIApplication.shared.open(storyShareURL, options: [:], completionHandler: nil)
-            } else {
-                print("인스타 앱이 깔려있지 않습니다.")
-            }
+        let activityItems : NSMutableArray = []
+        activityItems.add(imageToShare)
+
+        guard let url = saveImageOnPhone(image: imageToShare, image_name: "WAL") else {
+            return
+        }
+        
+        let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        activityVC.excludedActivityTypes = [UIActivity.ActivityType.addToReadingList]
+        
+        self.present(activityVC, animated: true, completion: nil)
+    }
+    
+    private func saveImageOnPhone(image: UIImage, image_name: String) -> URL? {
+        let imagePath: String = "\(NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0])/\(image_name).png"
+        let imageUrl: URL = URL(fileURLWithPath: imagePath)
+        
+        do {
+            try image.pngData()?.write(to: imageUrl)
+            return imageUrl
+        } catch {
+            return nil
         }
     }
 }

--- a/WAL/WAL/Screen/Main/Controller/MainViewController.swift
+++ b/WAL/WAL/Screen/Main/Controller/MainViewController.swift
@@ -150,7 +150,7 @@ final class MainViewController: UIViewController {
         super.viewWillAppear(animated)
         configNavigationUI()
         checkTime()
-        print(#function)
+        NotificationCenter.default.addObserver(self, selector: #selector(getNotification), name: NSNotification.Name("EnterMain"), object: nil)
     }
     
     override func viewDidLoad() {
@@ -267,6 +267,18 @@ final class MainViewController: UIViewController {
         }
     }
     
+    private func saveImageOnPhone(image: UIImage, image_name: String) -> URL? {
+        let imagePath: String = "\(NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0])/\(image_name).png"
+        let imageUrl: URL = URL(fileURLWithPath: imagePath)
+        
+        do {
+            try image.pngData()?.write(to: imageUrl)
+            return imageUrl
+        } catch {
+            return nil
+        }
+    }
+    
     // MARK: - @objc
     
     @objc func touchupAddButton() {
@@ -323,16 +335,8 @@ final class MainViewController: UIViewController {
         self.present(activityVC, animated: true, completion: nil)
     }
     
-    private func saveImageOnPhone(image: UIImage, image_name: String) -> URL? {
-        let imagePath: String = "\(NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0])/\(image_name).png"
-        let imageUrl: URL = URL(fileURLWithPath: imagePath)
-        
-        do {
-            try image.pngData()?.write(to: imageUrl)
-            return imageUrl
-        } catch {
-            return nil
-        }
+    @objc func getNotification() {
+        checkTime()
     }
 }
 


### PR DESCRIPTION
## 🌱 작업한 내용
- 앱간 이동으로 인스타그램 스토리 공유 -> UIActivityViewController로 공유하기 기능 변경했습니다. 
- 앱이 Background -> Foreground로 왔을 때 로티 애니메이션 실행 오류 

## 🌱 PR Point
- 스토리 공유의 경우 UIActivityViewController에서 인스타그램 앱을 선택하면 나오는 기능에 따라서 구현이 되도록 했습니다. 그런데 이유는 모르겠는데 (아마 계정 공개 범위 .. 그러니까 비공개/공개) 계정에 따라서 스토리 공유가 보이기도 하고 안보이기도 해서 .. 일단은 이렇게 구현해서 올립니다 !! 
- 앱이 Background에 있다가 Foreground로 이동하면 로티 애니메이션이 중단되는 이슈가 있어서 오류 해결해서 올립니다 !! 

## 📮 관련 이슈
- Resolved: #42 
