### PR TITLE
[Fix] 환경설정, 온보딩 QA 반영

### DIFF
--- a/WAL/WAL.xcodeproj/project.pbxproj
+++ b/WAL/WAL.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		5BD35864289D482E0066C804 /* ZanzanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD35863289D482E0066C804 /* ZanzanView.swift */; };
 		5BE2E5FC28572C8E0053AF4C /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5BE2E5FB28572C8E0053AF4C /* GoogleService-Info.plist */; };
 		5BECCA8F286A43B800DD70A3 /* MenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BECCA8E286A43B800DD70A3 /* MenuButton.swift */; };
+		5BFC216128B920F100E4F65A /* Transition+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFC216028B920F100E4F65A /* Transition+.swift */; };
 		9205E747286EE1A4000F4B6D /* MainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9205E746286EE1A4000F4B6D /* MainService.swift */; };
 		9205E749286EE1AD000F4B6D /* MainAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9205E748286EE1AD000F4B6D /* MainAPI.swift */; };
 		9205E74C286EE4CF000F4B6D /* MainResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9205E74B286EE4CF000F4B6D /* MainResponse.swift */; };
@@ -197,6 +198,7 @@
 		5BD35863289D482E0066C804 /* ZanzanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZanzanView.swift; sourceTree = "<group>"; };
 		5BE2E5FB28572C8E0053AF4C /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		5BECCA8E286A43B800DD70A3 /* MenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuButton.swift; sourceTree = "<group>"; };
+		5BFC216028B920F100E4F65A /* Transition+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Transition+.swift"; sourceTree = "<group>"; };
 		9205E746286EE1A4000F4B6D /* MainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainService.swift; sourceTree = "<group>"; };
 		9205E748286EE1AD000F4B6D /* MainAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainAPI.swift; sourceTree = "<group>"; };
 		9205E74B286EE4CF000F4B6D /* MainResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainResponse.swift; sourceTree = "<group>"; };
@@ -444,6 +446,7 @@
 				5B020D36281EAF020057F9B7 /* String+.swift */,
 				5B020D38281F107C0057F9B7 /* UIViewController+.swift */,
 				5B567E2028B0FCC300BF9E17 /* NSNotification.Name+.swift */,
+				5BFC216028B920F100E4F65A /* Transition+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1075,6 +1078,7 @@
 				5B020D3F281F31B00057F9B7 /* AlarmCollectionViewCell.swift in Sources */,
 				9213AD072865AB67009B6002 /* HistoryService.swift in Sources */,
 				5BA3897427F6C6290010EAA1 /* UIScreen+.swift in Sources */,
+				5BFC216128B920F100E4F65A /* Transition+.swift in Sources */,
 				5B44E58328A6C174000ABF0C /* UserInfo.swift in Sources */,
 				E213130528608077001238F3 /* CreateInformationViewController.swift in Sources */,
 				5BB17B372865BAB100029824 /* Onboard.swift in Sources */,

--- a/WAL/WAL.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WAL/WAL.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/zanzanbari/WALKit.git",
         "state": {
           "branch": "develop",
-          "revision": "b7347f9ca36f3908479b74d01c2c3446d7b64657",
+          "revision": "8520711a5442393caf75b78eefe2ee58740ce47e",
           "version": null
         }
       }

--- a/WAL/WAL/Global/Extension/Transition+.swift
+++ b/WAL/WAL/Global/Extension/Transition+.swift
@@ -1,0 +1,56 @@
+//
+//  Transition+.swift
+//  WAL
+//
+//  Created by heerucan on 2022/08/27.
+//
+
+import UIKit
+
+extension UIViewController {
+    enum TransitionStyle {
+        case presentNavigation // 네비게이션 임베드 present
+        case present // 네비게이션 없이 present
+        case presentFullNavigation // 네비게이션 풀스크린
+        case push
+        case dismiss
+        case presentedViewDismiss // presentingViewController 보여주기
+        case pop
+    }
+    
+    func transition<T: UIViewController>(_ viewController: T,
+                                         _ style: TransitionStyle = .push,
+                                         completion: ((T) -> Void)? = nil) {
+        
+        completion?(viewController)
+        
+        switch style {
+        case .presentNavigation:
+            let navi = UINavigationController(rootViewController: viewController)
+            viewController.modalPresentationStyle = .fullScreen
+            self.present(navi, animated: true)
+            
+        case .present:
+            self.present(viewController, animated: true)
+            
+        case .push:
+            self.navigationController?.pushViewController(viewController, animated: true)
+            
+        case .presentFullNavigation:
+            let navi = UINavigationController(rootViewController: viewController)
+            navi.modalPresentationStyle = .fullScreen
+            self.present(navi, animated: true)
+            
+        case .dismiss:
+            self.dismiss(animated: true)
+            
+        case .presentedViewDismiss:
+            self.dismiss(animated: true) {
+                viewController.viewWillAppear(true)
+            }
+            
+        case .pop:
+            navigationController?.popViewController(animated: true)
+        }
+    }
+}

--- a/WAL/WAL/Resource/Support/Info.plist
+++ b/WAL/WAL/Resource/Support/Info.plist
@@ -2,17 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>instagram-stories</string>
-	</array>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -24,8 +13,9 @@
 			</array>
 		</dict>
 	</array>
-	<key>LSApplicationQueriesShcemes</key>
+	<key>LSApplicationQueriesSchemes</key>
 	<array>
+		<string>kakaolink</string>
 		<string>kakaokompassauth</string>
 		<string>instagram-stories</string>
 	</array>

--- a/WAL/WAL/Screen/Create/View/WALPopupView.swift
+++ b/WAL/WAL/Screen/Create/View/WALPopupView.swift
@@ -71,7 +71,7 @@ class WALPopupView: UIView {
         makeRound(radius: 15)
         
         [horizontalLineView, verticalLineView].forEach {
-            $0.backgroundColor = .gray300
+            $0.backgroundColor = .gray500
         }
         
         [leftButton, rightButton].forEach {

--- a/WAL/WAL/Screen/Login/Controller/LoginViewController.swift
+++ b/WAL/WAL/Screen/Login/Controller/LoginViewController.swift
@@ -71,7 +71,7 @@ final class LoginViewController: UIViewController {
         }
         
         appleButton.snp.makeConstraints { make in
-            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(80)
+            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(46)
             make.leading.trailing.equalToSuperview().inset(20)
         }
     }

--- a/WAL/WAL/Screen/Onboarding/Controller/OnboardCompleteViewController.swift
+++ b/WAL/WAL/Screen/Onboarding/Controller/OnboardCompleteViewController.swift
@@ -26,7 +26,6 @@ final class OnboardCompleteViewController: UIViewController {
     }
     
     private let subLabel = UILabel().then {
-        $0.text = "쟌쟌바리님 맞춤 설정을 끝냈어요\n왈을 시작해볼까요?"
         $0.font = WALFont.body5.font
         $0.numberOfLines = 2
         $0.textColor = .gray100
@@ -51,6 +50,9 @@ final class OnboardCompleteViewController: UIViewController {
     
     private func configUI() {
         view.backgroundColor = .white
+        guard let nickname = UserDefaults.standard.string(forKey: Constant.Key.nickname)
+        else { return }
+        subLabel.text = nickname + "님 맞춤 설정을 끝냈어요\n왈을 시작해볼까요?"
         subLabel.addLineSpacing(spacing: 0.4)
         subLabel.addLetterSpacing()
     }

--- a/WAL/WAL/Screen/Onboarding/Controller/OnboardingViewController.swift
+++ b/WAL/WAL/Screen/Onboarding/Controller/OnboardingViewController.swift
@@ -89,7 +89,7 @@ final class OnboardingViewController: UIViewController {
         }
         
         pageControl.snp.makeConstraints { make in
-            make.top.bottom.equalToSuperview().inset(UIScreen.main.hasNotch ? 11 : 4)
+            make.top.bottom.equalToSuperview().inset(UIScreen.main.hasNotch ? 10 : 4)
             make.centerX.equalToSuperview()
         }
         

--- a/WAL/WAL/Screen/Onboarding/View/AlarmCollectionViewCell.swift
+++ b/WAL/WAL/Screen/Onboarding/View/AlarmCollectionViewCell.swift
@@ -20,7 +20,7 @@ class AlarmCollectionViewCell: BaseCollectionViewCell {
     
     private let titleLabel = UILabel().then {
         $0.font = WALFont.title2.font
-        $0.text = "언제 알림이 \n 울리길 원하나요?"
+        $0.text = "언제 알림이\n울리길 원하나요?"
         $0.textAlignment = .center
         $0.numberOfLines = 2
     }
@@ -63,6 +63,7 @@ class AlarmCollectionViewCell: BaseCollectionViewCell {
     
     private func configUI() {
         contentView.backgroundColor = .white100
+        titleLabel.addLetterSpacing()
         [moringButtoon, afternoonButton, nightButton].forEach {
             $0.addTarget(self, action: #selector(touchupButton(sender:)), for: .touchUpInside)
         }

--- a/WAL/WAL/Screen/Onboarding/View/CategoryCollectionViewCell.swift
+++ b/WAL/WAL/Screen/Onboarding/View/CategoryCollectionViewCell.swift
@@ -84,6 +84,7 @@ class CategoryCollectionViewCell: BaseCollectionViewCell {
         contentView.backgroundColor = .white100
         barWidth = (contentView.frame.width-61*2)/4
         [jokeButton, complimentButton, condolenceButton, scoldingButton].forEach {
+            $0.categorySubLabel.addLetterSpacing()
             $0.addTarget(self, action: #selector(touchupButton(sender:)), for: .touchUpInside)
         }
     }
@@ -165,7 +166,8 @@ class CategoryCollectionViewCell: BaseCollectionViewCell {
     
     @objc func changeNickname(_ notification: Notification) {
         guard let nickname = notification.userInfo?["nickname"] as? String else { return }
-        titleLabel.text = nickname + "님이 받고싶은 \n 왈소리 유형은?"
+        titleLabel.text = nickname + "님이 받고싶은\n왈소리 유형은?"
+        titleLabel.addLetterSpacing()
     }
     
     @objc func touchupButton(sender: UIButton) {

--- a/WAL/WAL/Screen/Onboarding/View/Component/CardButton.swift
+++ b/WAL/WAL/Screen/Onboarding/View/Component/CardButton.swift
@@ -24,7 +24,7 @@ class CardButton: UIButton {
         $0.textAlignment = .center
     }
     
-    private let categorySubLabel = UILabel().then {
+    let categorySubLabel = UILabel().then {
         $0.font = WALFont.body7.font
         $0.textColor = .black100
         $0.textAlignment = .center

--- a/WAL/WAL/Screen/Onboarding/View/OnboardingCollectionViewCell.swift
+++ b/WAL/WAL/Screen/Onboarding/View/OnboardingCollectionViewCell.swift
@@ -19,7 +19,7 @@ class OnboardingCollectionViewCell: BaseCollectionViewCell {
     
     let titleLabel = UILabel().then {
         $0.font = WALFont.title2.font
-        $0.text = "왈이 당신을 뭐라고 \n 부르면 되나요?"
+        $0.text = "왈뿡이가 당신을 뭐라고\n부르면 되나요?"
         $0.textAlignment = .center
         $0.numberOfLines = 2
     }
@@ -64,6 +64,7 @@ class OnboardingCollectionViewCell: BaseCollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        configUI()
         setupLayout()
         setupTextField()
         nicknameTextField.becomeFirstResponder()
@@ -74,6 +75,10 @@ class OnboardingCollectionViewCell: BaseCollectionViewCell {
     }
     
     // MARK: - InitUI
+    
+    private func configUI() {
+        titleLabel.addLetterSpacing()
+    }
     
     private func setupLayout() {
         contentView.addSubviews([titleLabel,

--- a/WAL/WAL/Screen/Setting/Controller/SettingAlarmViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SettingAlarmViewController.swift
@@ -80,7 +80,7 @@ final class SettingAlarmViewController: UIViewController {
                                                   nightButton])
         
         navigationBar.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(47)
+            make.top.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview()
         }
         
@@ -167,7 +167,7 @@ extension SettingAlarmViewController {
                     self.morningButton.isSelected = userAlarmData.morning
                     self.afternoonButton.isSelected = userAlarmData.afternoon
                     self.nightButton.isSelected = userAlarmData.night
-                    self.dismiss(animated: true, completion: nil)
+                    self.transition(self, .pop)
                 } else {
                     print("🥰 알림시간 수정 서버 통신 실패로 화면전환 실패")
                 }

--- a/WAL/WAL/Screen/Setting/Controller/SettingCategoryViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SettingCategoryViewController.swift
@@ -129,7 +129,6 @@ final class SettingCategoryViewController: UIViewController {
     }
     
     @objc func touchupButton(_ sender: UIButton) {
-        print(sender.tag, "선택한 버튼")
         sender.isSelected = !sender.isSelected
         sender.layer.borderColor = sender.isSelected ?
         UIColor.orange100.cgColor : UIColor.gray400.cgColor
@@ -164,10 +163,10 @@ extension SettingCategoryViewController {
     private func postCategory() {
         SettingAPI.shared.postUserCategory(data: [
             categoryBeforeChange,
-            CategoryType(self.jokeButton.isSelected,
-                         self.complimentButton.isSelected,
-                         self.condolenceButton.isSelected,
-                         self.scoldingButton.isSelected)]) { (userCategory, nil) in
+            CategoryType(jokeButton.isSelected,
+                         complimentButton.isSelected,
+                         condolenceButton.isSelected,
+                         scoldingButton.isSelected)]) { (userCategory, nil) in
                              guard let userCategory = userCategory,
                                    let userCategoryData = userCategory.data else { return }
                              if userCategory.status < 400 {

--- a/WAL/WAL/Screen/Setting/Controller/SettingCategoryViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SettingCategoryViewController.swift
@@ -67,7 +67,7 @@ final class SettingCategoryViewController: UIViewController {
          complimentButton,
          condolenceButton,
          scoldingButton].forEach {
-            $0.addTarget(self, action: #selector(touchupButton(sender:)), for: .touchUpInside)
+            $0.addTarget(self, action: #selector(touchupButton(_:)), for: .touchUpInside)
         }
     }
     
@@ -82,7 +82,7 @@ final class SettingCategoryViewController: UIViewController {
         secondCategoryStackView.addArrangedSubviews([condolenceButton, scoldingButton])
         
         navigationBar.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(47)
+            make.top.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview()
         }
         
@@ -97,7 +97,7 @@ final class SettingCategoryViewController: UIViewController {
         }
         
         firstCategoryStackView.snp.makeConstraints { make in
-            make.top.equalTo(subtitleLabel.snp.bottom).offset(16)
+            make.top.equalTo(subtitleLabel.snp.bottom).offset(20)
             make.leading.trailing.equalToSuperview().inset(20)
             make.height.equalTo(163)
         }
@@ -128,7 +128,8 @@ final class SettingCategoryViewController: UIViewController {
         }
     }
     
-    @objc func touchupButton(sender: UIButton) {
+    @objc func touchupButton(_ sender: UIButton) {
+        print(sender.tag, "선택한 버튼")
         sender.isSelected = !sender.isSelected
         sender.layer.borderColor = sender.isSelected ?
         UIColor.orange100.cgColor : UIColor.gray400.cgColor
@@ -175,7 +176,7 @@ extension SettingCategoryViewController {
                                  self.complimentButton.isSelected = userCategoryData.compliment
                                  self.condolenceButton.isSelected = userCategoryData.condolence
                                  self.scoldingButton.isSelected = userCategoryData.scolding
-                                 self.dismiss(animated: true, completion: nil)
+                                 self.transition(self, .pop)
                              } else {
                                  print("🌈 카테고리 수정 서버 통신 실패로 화면전환 실패")
                              }

--- a/WAL/WAL/Screen/Setting/Controller/SettingViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SettingViewController.swift
@@ -28,13 +28,14 @@ class SettingViewController: UIViewController, SendNicknameDelegate {
         $0.backgroundColor = .white100
     }
     
-    private lazy var tableView = UITableView(frame: .zero, style: .plain).then {
+    private lazy var tableView = UITableView(frame: .zero, style: .grouped).then {
         $0.backgroundColor = .gray600
         $0.separatorStyle = .none
         $0.allowsSelection = true
         $0.delegate = self
         $0.dataSource = self
         $0.sectionHeaderTopPadding = 0
+        $0.sectionFooterHeight = 0
     }
     
     // MARK: - Life Cycle
@@ -57,7 +58,7 @@ class SettingViewController: UIViewController, SendNicknameDelegate {
         view.addSubviews([navigationBar, tableView, backView])
         
         navigationBar.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(47)
+            make.top.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview()
         }
         
@@ -103,36 +104,29 @@ extension SettingViewController: UITableViewDelegate {
         switch indexPath.section {
         case 0:
             let viewController = MypageViewController()
-            viewController.modalPresentationStyle = .overFullScreen
+            transition(viewController)
             viewController.nickname = nickname
             viewController.sendNicknameDelegate = self
-            present(viewController, animated: true, completion: nil)
         case 1:
             if indexPath.row == 0 {
                 let viewController = SettingAlarmViewController()
-                viewController.modalPresentationStyle = .overFullScreen
-                present(viewController, animated: true, completion: nil)
+                transition(viewController)
             } else if indexPath.row == 1 {
                 let viewController = SettingCategoryViewController()
-                viewController.modalPresentationStyle = .overFullScreen
-                present(viewController, animated: true, completion: nil)
+                transition(viewController)
             }
         default:
             if indexPath.row == 0 {
                 let viewController = ZanzanbariViewController()
-                viewController.modalPresentationStyle = .overFullScreen
-                present(viewController, animated: true, completion: nil)
+                transition(viewController)
             } else if indexPath.row == 1 {
                 guard let url = NSURL(string: Constant.URL.walURL) else { return }
                 let safariView: SFSafariViewController = SFSafariViewController(url: url as URL)
-                safariView.modalPresentationStyle = .overFullScreen
-                self.present(safariView, animated: true)
-                
+                transition(safariView, .present)
             } else if indexPath.row == 2 {
                 guard let url = NSURL(string: Constant.URL.serviceURL) else { return }
                 let safariView: SFSafariViewController = SFSafariViewController(url: url as URL)
-                safariView.modalPresentationStyle = .overFullScreen
-                self.present(safariView, animated: true)
+                transition(safariView, .present)
             }
             break
         }

--- a/WAL/WAL/Screen/Setting/Controller/SubController/EditNicknameViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SubController/EditNicknameViewController.swift
@@ -94,7 +94,7 @@ final class EditNicknameViewController: BaseViewController {
                           warnLabel])
         
         navigationBar.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(47)
+            make.top.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview()
         }
         
@@ -173,7 +173,6 @@ final class EditNicknameViewController: BaseViewController {
             self.sendNicknameDelegate?.sendNickname(userInfoData.nickname)
         }
         self.view.endEditing(true)
-        self.dismiss(animated: true)
     }
 }
 

--- a/WAL/WAL/Screen/Setting/Controller/SubController/LogoutPopupViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SubController/LogoutPopupViewController.swift
@@ -60,7 +60,7 @@ final class LogoutPopupViewController: UIViewController {
     // MARK: - @objc
     
     @objc func touchupCancelButton() {
-        dismiss(animated: true)
+        dismiss(animated: false)
     }
     
     @objc func touchupOkButton() {

--- a/WAL/WAL/Screen/Setting/Controller/SubController/MypageViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SubController/MypageViewController.swift
@@ -101,7 +101,7 @@ class MypageViewController: UIViewController, SendNicknameDelegate {
         }
         
         navigationBar.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(47)
+            make.top.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview()
         }
         
@@ -151,20 +151,16 @@ class MypageViewController: UIViewController, SendNicknameDelegate {
         switch sender {
         case navigationBar.leftBarButton:
             sendNicknameDelegate?.sendNickname(nickname)
-            self.dismiss(animated: true, completion: nil)
-            
+            transition(self, .pop)
         case nicknameButton:
             let viewController = EditNicknameViewController()
             viewController.modalPresentationStyle = .overFullScreen
             viewController.nickname = nickname
             viewController.sendNicknameDelegate = self
-            self.present(viewController, animated: false, completion: nil)
-            
+            present(viewController, animated: false)
         case resignButton:
             let viewController = ResignViewController()
-            viewController.modalPresentationStyle = .overFullScreen
-            present(viewController, animated: true, completion: nil)
-            
+            transition(viewController)
         default:
             let popupViewController = LogoutPopupViewController()
             popupViewController.modalPresentationStyle = .overFullScreen

--- a/WAL/WAL/Screen/Setting/Controller/SubController/ResignViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SubController/ResignViewController.swift
@@ -56,13 +56,14 @@ final class ResignViewController: UIViewController {
     
     private func configUI() {
         view.backgroundColor = .white
+        
     }
     
     private func setupLayout() {
         view.addSubviews([navigationBar, tableView, backView, resignButton])
         
         navigationBar.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(47)
+            make.top.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview()
         }
         
@@ -100,7 +101,7 @@ final class ResignViewController: UIViewController {
     // MARK: - @objc
     
     @objc func touchupBackButton() {
-        self.dismiss(animated: true, completion: nil)
+        transition(self, .pop)
     }
     
     @objc func touchupResignButton(_ sender: UIButton) {
@@ -121,7 +122,7 @@ final class ResignViewController: UIViewController {
     @objc func touchupCheckButton(_ sender: UIButton) {
         resignData[sender.tag].select = !resignData[sender.tag].select
         reasonData = resignData.filter({$0.select}).map { $0.menu }
-        tableView.reloadRows(at: [IndexPath(row: sender.tag, section: 0)], with: .automatic)
+        tableView.reloadRows(at: [IndexPath(row: sender.tag, section: 0)], with: .none)
     }
 }
 

--- a/WAL/WAL/Screen/Setting/Controller/SubController/ResignViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SubController/ResignViewController.swift
@@ -174,4 +174,10 @@ extension ResignViewController: UITableViewDataSource {
         cell.checkButton.addTarget(self, action: #selector(touchupCheckButton(_:)), for: .touchUpInside)
         return cell
     }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let cell = tableView.cellForRow(at: IndexPath(row: indexPath.row, section: 0)) as? ResignTableViewCell
+        else { return }
+        touchupCheckButton(cell.checkButton)
+    }
 }

--- a/WAL/WAL/Screen/Setting/Controller/ZanzanbariViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/ZanzanbariViewController.swift
@@ -38,7 +38,7 @@ final class ZanzanbariViewController: UIViewController {
     }
     
     private let lineView = UIView().then {
-        $0.backgroundColor = .gray700
+        $0.backgroundColor = .gray500
     }
     
     private let designView = ZanzanView().then {

--- a/WAL/WAL/Screen/Setting/Controller/ZanzanbariViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/ZanzanbariViewController.swift
@@ -111,7 +111,7 @@ final class ZanzanbariViewController: UIViewController {
         statusBarView.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(47)
+            make.bottom.equalTo(navigationBar.snp.top)
         }
         
         navigationBar.snp.makeConstraints { make in

--- a/WAL/WAL/Screen/Setting/Controller/ZanzanbariViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/ZanzanbariViewController.swift
@@ -38,7 +38,7 @@ final class ZanzanbariViewController: UIViewController {
     }
     
     private let lineView = UIView().then {
-        $0.backgroundColor = .gray400
+        $0.backgroundColor = .gray700
     }
     
     private let designView = ZanzanView().then {
@@ -115,7 +115,7 @@ final class ZanzanbariViewController: UIViewController {
         }
         
         navigationBar.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(47)
+            make.top.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview()
         }
         
@@ -171,13 +171,12 @@ final class ZanzanbariViewController: UIViewController {
     // MARK: - @objc
     
     @objc func touchupBackButton() {
-        self.dismiss(animated: true, completion: nil)
+        transition(self, .pop)
     }
     
     @objc func touchupSendOpinionButton() {
         guard let url = NSURL(string: Constant.URL.walURL) else { return }
         let safariView: SFSafariViewController = SFSafariViewController(url: url as URL)
-        safariView.modalPresentationStyle = .overFullScreen
-        self.present(safariView, animated: true)
+        transition(safariView, .present)
     }
 }

--- a/WAL/WAL/Screen/Setting/View/Component/ResignHeaderView.swift
+++ b/WAL/WAL/Screen/Setting/View/Component/ResignHeaderView.swift
@@ -62,7 +62,7 @@ class ResignHeaderView: UIView {
         addSubviews([cryingImageView, titleLabel, subtitleLabel, menuTitleLabel])
         
         cryingImageView.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(35)
+            make.top.equalToSuperview().inset(33)
             make.centerX.equalToSuperview()
             make.width.equalTo(142)
             make.height.equalTo(127)

--- a/WAL/WAL/Screen/Setting/View/Component/ResignHeaderView.swift
+++ b/WAL/WAL/Screen/Setting/View/Component/ResignHeaderView.swift
@@ -53,6 +53,7 @@ class ResignHeaderView: UIView {
     
     private func configUI() {
         backgroundColor = .white
+        titleLabel.addLetterSpacing()
         subtitleLabel.addLetterSpacing(kernValue: -0.4, paragraphValue: 8.0)
         subtitleLabel.textAlignment = .left
     }
@@ -74,7 +75,7 @@ class ResignHeaderView: UIView {
         }
         
         subtitleLabel.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(16)
+            make.top.equalTo(titleLabel.snp.bottom).offset(20)
             make.leading.trailing.equalToSuperview().inset(20)
         }
         


### PR DESCRIPTION
## 🌱 작업한 내용

- 환경설정, 온보딩 큐에이 반영했습니다.

## 🌱 PR Point

- 스플래시 및 로티는 따로 이슈가 있어서 거기서 작업하려고 합니다. 
- 추가로, 카테고리 유형 설정에서 
`드립만 선택 → 드립+위로 / 주접만 선택 → 주접+위로 / 꾸중만 선택 → 위로 // 왈소리 유형 선택 후 나갔다가 돌아오면 화살표 다음의 상태로 변경되어있어용` 
해당 이슈는 제 눈깔이 이상한 건지 ... 제가 서버에 request할 때 분명 순서를 
joke -> compliment -> condolence -> scolding 순으로 보내거든요..? 근데 logger에 찍힌 거 보면 이렇게 되어 있는데 문제는.. 
<img width="692" alt="스크린샷 2022-08-27 오후 2 27 31" src="https://user-images.githubusercontent.com/63235947/187016246-04edf5f6-7562-43b6-bfde-bb5329aacf19.png">

제가 카테고리 유형 수정하기/가져오기 데이터 찍어보면 제대로 잘 보내졌다는 것입니다..
데이터모델 순서도 잘 확인했고,, 그래서.. 내 코드라 내가 못보나 싶어서... 도라버린.... 한 번 확인 부탁해주십사....ㅠ
<img width="921" alt="스크린샷 2022-08-27 오후 2 28 26" src="https://user-images.githubusercontent.com/63235947/187016267-a4ac752b-dde7-4648-be3f-004ed20b8c1e.png">
<img width="957" alt="스크린샷 2022-08-27 오후 2 28 35" src="https://user-images.githubusercontent.com/63235947/187016272-93ca74f7-0db5-41de-9179-146b049555d8.png">

아 근ㄱ데 지금 서버랑 열시미 체킹 중임... 해결하겟삼..샤발


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Closed: #47 
