### PR TITLE
[Fix] 히스토리 뷰 1차 QA (#48)

### DIFF
--- a/WAL/WAL.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WAL/WAL.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "SnapKit",
-        "repositoryURL": "https://github.com/SnapKit/SnapKit",
-        "state": {
-          "branch": null,
-          "revision": "f222cbdf325885926566172f6f5f06af95473158",
-          "version": "5.6.0"
-        }
-      },
-      {
-        "package": "WALKit",
-        "repositoryURL": "https://github.com/zanzanbari/WALKit.git",
-        "state": {
-          "branch": "develop",
-          "revision": "b7347f9ca36f3908479b74d01c2c3446d7b64657",
-          "version": null
-        }
+  "pins" : [
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit",
+      "state" : {
+        "revision" : "f222cbdf325885926566172f6f5f06af95473158",
+        "version" : "5.6.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "walkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zanzanbari/WALKit.git",
+      "state" : {
+        "branch" : "develop",
+        "revision" : "2e5c56fce0c18a0f223872805c17e0c4bc8bc0a9"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/WAL/WAL/Global/Protocol/Protocol.swift
+++ b/WAL/WAL/Global/Protocol/Protocol.swift
@@ -41,3 +41,7 @@ protocol SendCategoryDelegate: OnboardingViewController {
 protocol SendAlarmTimeDelegate: OnboardingViewController {
     func sendAlarmTime(morning: Bool, afternoon: Bool, night: Bool)
 }
+
+protocol ResendWalDelegate {
+    func resendToCreate(_ vc: UIViewController, walsound: String)
+}

--- a/WAL/WAL/Screen/Create/Controller/CreateViewController.swift
+++ b/WAL/WAL/Screen/Create/Controller/CreateViewController.swift
@@ -276,7 +276,8 @@ class CreateViewController: UIViewController {
     
     @objc private func touchUpHistoryButton() {
         let historyViewController = HistoryViewController()
-        navigationController?.pushViewController(historyViewController, animated: true)
+        historyViewController.modalPresentationStyle = .overFullScreen
+        present(historyViewController, animated: true)
     }
     
     //MARK: - CustomMethod

--- a/WAL/WAL/Screen/Create/Controller/CreateViewController.swift
+++ b/WAL/WAL/Screen/Create/Controller/CreateViewController.swift
@@ -276,6 +276,7 @@ class CreateViewController: UIViewController {
     
     @objc private func touchUpHistoryButton() {
         let historyViewController = HistoryViewController()
+        historyViewController.delegate = self
         historyViewController.modalPresentationStyle = .overFullScreen
         present(historyViewController, animated: true)
     }
@@ -455,5 +456,13 @@ extension CreateViewController {
             guard let data = data else { return }
             print(data)
         }
+    }
+}
+
+//MARK: - Protocol
+extension CreateViewController: ResendWalDelegate {
+    func resendToCreate(_ vc: UIViewController, walsound: String) {
+        walSoundTextView.text = walsound
+        (walsound.count == 0) ? (placeholderLabel.isHidden = false) : (placeholderLabel.isHidden = true)
     }
 }

--- a/WAL/WAL/Screen/Create/Controller/CreateViewController.swift
+++ b/WAL/WAL/Screen/Create/Controller/CreateViewController.swift
@@ -464,5 +464,14 @@ extension CreateViewController: ResendWalDelegate {
     func resendToCreate(_ vc: UIViewController, walsound: String) {
         walSoundTextView.text = walsound
         (walsound.count == 0) ? (placeholderLabel.isHidden = false) : (placeholderLabel.isHidden = true)
+        countLabel.text = "\(walSoundTextView.text.count)"
+        
+        countLabel.textColor = walSoundTextView.text.count >= 100 ? .orange100 : .gray200
+        
+        if walSoundTextView.text.count > 100 {
+            walSoundTextView.deleteBackward()
+        }
+        
+        setSendButton()
     }
 }

--- a/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
+++ b/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
@@ -178,6 +178,7 @@ extension HistoryViewController: UITableViewDelegate {
         switch section {
         case 0:
             reserveHeader.title = "보내는 중"
+            reserveHeader.countLabel.text = String(sendingData.count)
             return reserveHeader
         case 1:
             completeHeader.delegate = self

--- a/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
+++ b/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
@@ -35,6 +35,8 @@ final class HistoryViewController: UIViewController {
     var selectedIndex: IndexPath = []
     var selectedIndices: [IndexPath] = []
     
+    var delegate: ResendWalDelegate?
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -227,7 +229,8 @@ extension HistoryViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let resendAction = UIContextualAction(style: .normal, title: "재전송") { (UIContextualAction, UIView, success: @escaping (Bool) -> Void) in
-//            dismiss(animated: true)
+            self.delegate?.resendToCreate(self, walsound: "\(self.completeData[indexPath.row].content)")
+            self.presentingViewController?.dismiss(animated: true)
             success(true)
         }
         resendAction.backgroundColor = .mint100

--- a/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
+++ b/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
@@ -302,14 +302,12 @@ extension HistoryViewController: UITableViewDataSource {
         case 0:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: HistoryTableViewCell.cellIdentifier) as? HistoryTableViewCell else { return UITableViewCell() }
             cell.selectionStyle = .none
-            cell.sendingDateLabelColor = .systemMint
             cell.setData(sendingData[indexPath.row])
             selectedIndices.append([-1,-1])
             return cell
         case 1:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: HistoryTableViewCell.cellIdentifier) as? HistoryTableViewCell else { return UITableViewCell() }
             cell.selectionStyle = .none
-            cell.sendingDateLabelColor = .gray
             cell.setData(completeData[indexPath.row])
             selectedIndices.append([-1,-1])
             return cell

--- a/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
+++ b/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
@@ -183,6 +183,7 @@ extension HistoryViewController: UITableViewDelegate {
         case 1:
             completeHeader.delegate = self
             completeHeader.title = "완료"
+            completeHeader.countLabel.text = String(completeData.count)
             return completeHeader
         default:
             return UIView()

--- a/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
+++ b/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
@@ -308,6 +308,7 @@ extension HistoryViewController: UITableViewDataSource {
         case 1:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: HistoryTableViewCell.cellIdentifier) as? HistoryTableViewCell else { return UITableViewCell() }
             cell.selectionStyle = .none
+            cell.hideDdayView()
             cell.setData(completeData[indexPath.row])
             selectedIndices.append([-1,-1])
             return cell

--- a/WAL/WAL/Screen/History/View/HistoryCompleteHeaderView.swift
+++ b/WAL/WAL/Screen/History/View/HistoryCompleteHeaderView.swift
@@ -53,7 +53,7 @@ final class HistoryCompleteHeaderView: UIView {
     private var informationTitleLabel = UILabel().then {
         $0.text = "박스를 옆으로 밀어 재전송 할 수 있어요"
         $0.textColor = .white
-        $0.font = WALFont.body9.font
+        $0.font = WALFont.body10.font
         $0.addLetterSpacing()
     }
     

--- a/WAL/WAL/Screen/History/View/HistoryCompleteHeaderView.swift
+++ b/WAL/WAL/Screen/History/View/HistoryCompleteHeaderView.swift
@@ -88,7 +88,7 @@ final class HistoryCompleteHeaderView: UIView {
         }
         
         titleLabel.snp.makeConstraints {
-            $0.top.equalTo(divideView.snp.bottom).offset(27)
+            $0.top.equalTo(divideView.snp.bottom).offset(30)
             $0.leading.equalToSuperview().inset(20)
         }
         

--- a/WAL/WAL/Screen/History/View/HistoryCompleteHeaderView.swift
+++ b/WAL/WAL/Screen/History/View/HistoryCompleteHeaderView.swift
@@ -30,6 +30,11 @@ final class HistoryCompleteHeaderView: UIView {
         }
     }
     
+    var countLabel = UILabel().then {
+        $0.textColor = .black
+        $0.font = WALFont.body5.font
+    }
+    
     private var divideView = UIView().then {
         $0.backgroundColor = .gray600
     }
@@ -79,7 +84,7 @@ final class HistoryCompleteHeaderView: UIView {
     }
     
     private func setupLayout() {
-        addSubviews([titleLabel, bubbleImageView, divideView, informationButton])
+        addSubviews([titleLabel, countLabel, bubbleImageView, divideView, informationButton])
         bubbleImageView.addSubview(informationTitleLabel)
         
         divideView.snp.makeConstraints {
@@ -92,9 +97,14 @@ final class HistoryCompleteHeaderView: UIView {
             $0.leading.equalToSuperview().inset(20)
         }
         
+        countLabel.snp.makeConstraints {
+            $0.centerY.equalTo(titleLabel.snp.centerY)
+            $0.leading.equalTo(titleLabel.snp.trailing).offset(4)
+        }
+        
         informationButton.snp.makeConstraints {
             $0.centerY.equalTo(titleLabel.snp.centerY)
-            $0.leading.equalToSuperview().inset(45)
+            $0.leading.equalTo(countLabel.snp.trailing)
             $0.width.height.equalTo(30)
         }
         

--- a/WAL/WAL/Screen/History/View/HistoryReserveHeaderView.swift
+++ b/WAL/WAL/Screen/History/View/HistoryReserveHeaderView.swift
@@ -27,7 +27,6 @@ final class HistoryReserveHeaderView: UIView {
     }
     
     var countLabel = UILabel().then {
-        $0.text = "234"
         $0.textColor = .black
         $0.font = WALFont.body5.font
     }

--- a/WAL/WAL/Screen/History/View/HistoryReserveHeaderView.swift
+++ b/WAL/WAL/Screen/History/View/HistoryReserveHeaderView.swift
@@ -26,6 +26,12 @@ final class HistoryReserveHeaderView: UIView {
         }
     }
     
+    var countLabel = UILabel().then {
+        $0.text = "234"
+        $0.textColor = .black
+        $0.font = WALFont.body5.font
+    }
+    
     // MARK: - Initializer
     
     init() {
@@ -45,11 +51,15 @@ final class HistoryReserveHeaderView: UIView {
     }
     
     private func setupLayout() {
-        addSubview(titleLabel)
+        addSubviews([titleLabel, countLabel])
         
         titleLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(20)
             $0.leading.equalToSuperview().inset(20)
+        }
+        countLabel.snp.makeConstraints {
+            $0.centerY.equalTo(titleLabel.snp.centerY)
+            $0.leading.equalTo(titleLabel.snp.trailing).offset(4)
         }
     }
 }

--- a/WAL/WAL/Screen/History/View/HistoryReserveHeaderView.swift
+++ b/WAL/WAL/Screen/History/View/HistoryReserveHeaderView.swift
@@ -48,7 +48,7 @@ final class HistoryReserveHeaderView: UIView {
         addSubview(titleLabel)
         
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(21)
+            $0.top.equalToSuperview().inset(20)
             $0.leading.equalToSuperview().inset(20)
         }
     }

--- a/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
+++ b/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
@@ -158,7 +158,7 @@ class HistoryTableViewCell: UITableViewCell {
         }
         
         coverSubtitleLabel.snp.makeConstraints {
-            $0.top.equalTo(coverTitleLabel.snp.bottom).offset(3)
+            $0.top.equalTo(coverTitleLabel.snp.bottom).offset(5)
             $0.centerX.equalToSuperview()
         }
         

--- a/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
+++ b/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
@@ -148,7 +148,7 @@ class HistoryTableViewCell: UITableViewCell {
         
         lockIconImageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(40)
-            $0.leading.equalToSuperview().inset(139)
+            $0.leading.equalToSuperview().inset(137)
             $0.width.height.equalTo(22)
         }
         

--- a/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
+++ b/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
@@ -57,7 +57,6 @@ class HistoryTableViewCell: UITableViewCell {
     
     var dDayLabel = UILabel().then {
         $0.text = "D-6"
-        //TODO: 나중에 슬랙으로 물어보고 폰트 바꾸세요
         $0.font = WALFont.body8.font
         $0.textColor = .mint100
     }
@@ -71,8 +70,6 @@ class HistoryTableViewCell: UITableViewCell {
     private var contentLabel = UILabel().then {
         $0.textColor = .black
         $0.font = WALFont.body7.font
-        $0.numberOfLines = 0
-        $0.lineBreakMode = .byTruncatingTail
     }
     
     var reserveAtLabel = UILabel().then {
@@ -86,6 +83,13 @@ class HistoryTableViewCell: UITableViewCell {
         $0.axis = .vertical
         $0.alignment = .fill
         $0.distribution = .fill
+    }
+    
+    private lazy var dateStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.alignment = .fill
+        $0.distribution = .fillEqually
+//        $0.backgroundColor = .blue
     }
     
     var isExpanded: Bool = false {
@@ -129,8 +133,11 @@ class HistoryTableViewCell: UITableViewCell {
     
     private func setLayout() {
         contentView.addSubviews([backView, coverView, lineView])
-        dDayView.addSubview(dDayLabel)
-        historyStackView.addSubviews([dDayView, sendingDateLabel, contentLabel, reserveAtLabel])
+        historyStackView.addSubviews([dateStackView, contentLabel, reserveAtLabel])
+        dateStackView.addSubviews([dDayView, sendingDateLabel])
+//        dateStackView.addSubviews([sendingDateLabel])
+
+//        dDayView.addSubview(dDayLabel)
         backView.addSubviews([lineView, historyStackView])
         coverView.addSubviews([coverLineView, lockIconImageView, coverTitleLabel, coverSubtitleLabel])
         
@@ -176,25 +183,29 @@ class HistoryTableViewCell: UITableViewCell {
             $0.centerX.centerY.equalToSuperview()
         }
         
+        dateStackView.snp.makeConstraints {
+            $0.top.leading.equalToSuperview()
+            $0.centerX.equalToSuperview()
+        }
+        
         dDayView.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
-            $0.height.equalTo(22)
+            $0.centerY.equalToSuperview()
+            $0.width.height.equalTo(22)
         }
-        
-        dDayLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(6)
-            $0.leading.equalToSuperview().inset(6)
-            $0.centerX.centerY.equalToSuperview()
-        }
+//
+//        dDayLabel.snp.makeConstraints {
+//            $0.top.leading.equalToSuperview().inset(6)
+//            $0.centerX.centerY.equalToSuperview()
+//        }
         
         sendingDateLabel.snp.makeConstraints {
-            $0.top.equalToSuperview()
             $0.leading.equalTo(dDayView.snp.trailing).offset(7)
-            $0.centerY.equalTo(dDayView.snp.centerY)
+            $0.centerY.equalToSuperview()
         }
         
         contentLabel.snp.makeConstraints {
-            $0.top.equalTo(sendingDateLabel.snp.bottom).offset(15)
+            $0.top.equalTo(dateStackView.snp.bottom).offset(15)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(42).priority(250)
         }
@@ -207,18 +218,17 @@ class HistoryTableViewCell: UITableViewCell {
     
     // MARK: - Custom Method
     
+    override func prepareForReuse() {
+        dDayView.isHidden = false
+    }
+    
     func update() {
-        self.historyStackView.layoutIfNeeded()
+        contentLabel.numberOfLines = 0
+        historyStackView.layoutIfNeeded()
     }
     
     func hideDdayView() {
         dDayView.isHidden = true
-        dDayView.snp.makeConstraints {
-            $0.width.equalTo(0)
-        }
-        sendingDateLabel.snp.makeConstraints {
-            $0.leading.equalTo(dDayView.snp.trailing).offset(0)
-        }
     }
     
     internal func setData(_ data: HistoryData) {
@@ -238,6 +248,9 @@ class HistoryTableViewCell: UITableViewCell {
             $0.addLetterSpacing()
             $0.textAlignment = .left
         }
+        
+        contentLabel.numberOfLines = 1
+        contentLabel.lineBreakMode = .byTruncatingTail
         
         coverView.isHidden = data.hidden ?? false ? false : true
     }

--- a/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
+++ b/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
@@ -170,6 +170,7 @@ class HistoryTableViewCell: UITableViewCell {
         
         sendingDateLabel.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
+            $0.height.equalTo(17)
         }
         
         contentLabel.snp.makeConstraints {

--- a/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
+++ b/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
@@ -89,7 +89,6 @@ class HistoryTableViewCell: UITableViewCell {
         $0.axis = .horizontal
         $0.alignment = .fill
         $0.distribution = .fillEqually
-//        $0.backgroundColor = .blue
     }
     
     var isExpanded: Bool = false {
@@ -135,9 +134,8 @@ class HistoryTableViewCell: UITableViewCell {
         contentView.addSubviews([backView, coverView, lineView])
         historyStackView.addSubviews([dateStackView, contentLabel, reserveAtLabel])
         dateStackView.addSubviews([dDayView, sendingDateLabel])
-//        dateStackView.addSubviews([sendingDateLabel])
 
-//        dDayView.addSubview(dDayLabel)
+        dDayView.addSubview(dDayLabel)
         backView.addSubviews([lineView, historyStackView])
         coverView.addSubviews([coverLineView, lockIconImageView, coverTitleLabel, coverSubtitleLabel])
         
@@ -191,13 +189,13 @@ class HistoryTableViewCell: UITableViewCell {
         dDayView.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
             $0.centerY.equalToSuperview()
-            $0.width.height.equalTo(22)
+            $0.height.equalTo(22)
         }
-//
-//        dDayLabel.snp.makeConstraints {
-//            $0.top.leading.equalToSuperview().inset(6)
-//            $0.centerX.centerY.equalToSuperview()
-//        }
+
+        dDayLabel.snp.makeConstraints {
+            $0.top.leading.equalToSuperview().inset(6)
+            $0.centerX.centerY.equalToSuperview()
+        }
         
         sendingDateLabel.snp.makeConstraints {
             $0.leading.equalTo(dDayView.snp.trailing).offset(7)
@@ -229,6 +227,7 @@ class HistoryTableViewCell: UITableViewCell {
     
     func hideDdayView() {
         dDayView.isHidden = true
+        // TODO: 완료에서 hidden 처리 하면 보이는 공간 없애기
     }
     
     internal func setData(_ data: HistoryData) {

--- a/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
+++ b/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
@@ -50,9 +50,22 @@ class HistoryTableViewCell: UITableViewCell {
         $0.font = WALFont.body9.font
     }
     
+    var dDayView = UIView().then {
+        $0.backgroundColor = .mint100.withAlphaComponent(0.11)
+        $0.layer.cornerRadius = 10
+    }
+    
+    var dDayLabel = UILabel().then {
+        $0.text = "D-6"
+        //TODO: 나중에 슬랙으로 물어보고 폰트 바꾸세요
+        $0.font = WALFont.body8.font
+        $0.textColor = .mint100
+    }
+    
     private var sendingDateLabel = UILabel().then {
         $0.text = "보내는 날짜"
-        $0.font = WALFont.body8.font
+        $0.textColor = .gray200
+        $0.font = WALFont.body9.font
     }
     
     private var contentLabel = UILabel().then {
@@ -73,12 +86,6 @@ class HistoryTableViewCell: UITableViewCell {
         $0.axis = .vertical
         $0.alignment = .fill
         $0.distribution = .fill
-    }
-    
-    var sendingDateLabelColor: UIColor = .gray200 {
-        didSet {
-            sendingDateLabel.textColor = sendingDateLabelColor
-        }
     }
     
     var isExpanded: Bool = false {
@@ -122,7 +129,8 @@ class HistoryTableViewCell: UITableViewCell {
     
     private func setLayout() {
         contentView.addSubviews([backView, coverView, lineView])
-        historyStackView.addSubviews([sendingDateLabel, contentLabel, reserveAtLabel])
+        dDayView.addSubview(dDayLabel)
+        historyStackView.addSubviews([dDayView, sendingDateLabel, contentLabel, reserveAtLabel])
         backView.addSubviews([lineView, historyStackView])
         coverView.addSubviews([coverLineView, lockIconImageView, coverTitleLabel, coverSubtitleLabel])
         
@@ -168,9 +176,21 @@ class HistoryTableViewCell: UITableViewCell {
             $0.centerX.centerY.equalToSuperview()
         }
         
-        sendingDateLabel.snp.makeConstraints {
+        dDayView.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
-            $0.height.equalTo(17)
+            $0.height.equalTo(22)
+        }
+        
+        dDayLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(6)
+            $0.leading.equalToSuperview().inset(6)
+            $0.centerX.centerY.equalToSuperview()
+        }
+        
+        sendingDateLabel.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.equalTo(dDayView.snp.trailing).offset(7)
+            $0.centerY.equalTo(dDayView.snp.centerY)
         }
         
         contentLabel.snp.makeConstraints {

--- a/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
+++ b/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
@@ -211,10 +211,22 @@ class HistoryTableViewCell: UITableViewCell {
         self.historyStackView.layoutIfNeeded()
     }
     
+    func hideDdayView() {
+        dDayView.isHidden = true
+        dDayView.snp.makeConstraints {
+            $0.width.equalTo(0)
+        }
+        sendingDateLabel.snp.makeConstraints {
+            $0.leading.equalTo(dDayView.snp.trailing).offset(0)
+        }
+    }
+    
     internal func setData(_ data: HistoryData) {
         postId = data.postID
         
         isContentHidden = data.hidden ?? false
+        
+        //TODO: 디데이 계산해서 넣어주세요
         
         sendingDateLabel.text = "\(data.sendingDate)"
         


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 아직 모든 QA를 고치진 않았는데 올립니다
-  ‘숨김 왈소리’ ‘ 꾹 누르면~’ 간격 조금 넓혀주세용 → 1~2px 정도 ,,?
- 작성된 정보 텍스트(날짜, 시간, 전송예정/완료) 밑부분이 살짝 잘려욤 확인부탁혀 ~
- 글이 길어서 디폴트 상태에서 다 안보이는 애들을 뒤에 .. 붙여주세염
- ( 자물쇠+’숨김 왈소리’) x 위치값 살짝 조정했는데 확인 후 수정부탁드립니당
- 내비게이션에서 ‘보내는 중’ 텍스트까지의 여백 수정했슴다 21 -> 20
- '완료'텍스트 위 회색 박스 -> ‘완료'텍스트까지의 여백 수정했슴다 27->30
- '보내는 중' , '완료' 텍스트 옆에 개수를 추가했슴다
- '완료' 텍스트 옆의 info 아이콘 색이 바뀌었슴다
- d day 추가
- 히스토리 뷰 push에서 modal로 변경
- 재전송

를 고쳤습니다.

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 완료된 왈소리 원래 디데이 사라져야 하는데 그거 하다가 말았습니다.. 다음 큐에이때 고치겠습니다.
- 패키지 업데이트해서 develop이랑 충돌나는거 같은데 한번 보겠심다 컨플릭트 해결해야합니다!

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #48 
