### PR TITLE
[Fix] 히스토리 뷰 2차 QA (#57)

### DIFF
--- a/WAL/WAL/Global/Extension/String+.swift
+++ b/WAL/WAL/Global/Extension/String+.swift
@@ -20,4 +20,17 @@ extension String {
         }
         return false
     }
+    
+    func toDate(withFormat format: String = "yyyy. MM. dd")-> Date?{
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeZone = TimeZone.current
+        dateFormatter.locale = Locale.current
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
+        dateFormatter.dateFormat = format
+        let date = dateFormatter.date(from: self)
+
+        return date
+
+    }
 }

--- a/WAL/WAL/Global/Extension/String+.swift
+++ b/WAL/WAL/Global/Extension/String+.swift
@@ -21,7 +21,7 @@ extension String {
         return false
     }
     
-    func toDate(withFormat format: String = "yyyy. MM. dd")-> Date?{
+    func toDate(withFormat format: String = "yyyy. MM. dd")-> Date? {
 
         let dateFormatter = DateFormatter()
         dateFormatter.timeZone = TimeZone.current

--- a/WAL/WAL/Global/Protocol/Protocol.swift
+++ b/WAL/WAL/Global/Protocol/Protocol.swift
@@ -45,3 +45,7 @@ protocol SendAlarmTimeDelegate: OnboardingViewController {
 protocol ResendWalDelegate {
     func resendToCreate(_ vc: UIViewController, walsound: String)
 }
+
+protocol RefreshDelegate {
+    func refresh(_ vc: UIViewController)
+}

--- a/WAL/WAL/Global/Protocol/Protocol.swift
+++ b/WAL/WAL/Global/Protocol/Protocol.swift
@@ -42,10 +42,10 @@ protocol SendAlarmTimeDelegate: OnboardingViewController {
     func sendAlarmTime(morning: Bool, afternoon: Bool, night: Bool)
 }
 
-protocol ResendWalDelegate {
+protocol ResendWalDelegate: AnyObject{
     func resendToCreate(_ vc: UIViewController, walsound: String)
 }
 
-protocol RefreshDelegate {
+protocol RefreshDelegate: AnyObject {
     func refresh(_ vc: UIViewController)
 }

--- a/WAL/WAL/Network/DataModel/History/HistoryResponse.swift
+++ b/WAL/WAL/Network/DataModel/History/HistoryResponse.swift
@@ -17,12 +17,12 @@ struct HistoryResponse: Codable {
 
 struct HistoryData: Codable {
     let postID: Int
-    let sendingDate, content, reserveAt: String
+    let sendingDate, content, reserveAt, sendDueDate: String
     let hidden: Bool?
     
     enum CodingKeys: String, CodingKey {
         case postID = "postId"
-        case sendingDate, content, reserveAt, hidden
+        case sendingDate, content, reserveAt, sendDueDate, hidden
     }
     
     init(from decoder: Decoder) throws {
@@ -31,6 +31,7 @@ struct HistoryData: Codable {
         sendingDate = (try? values.decode(String.self, forKey: .sendingDate)) ?? ""
         content = (try? values.decode(String.self, forKey: .content)) ?? ""
         reserveAt = (try? values.decode(String.self, forKey: .reserveAt)) ?? ""
+        sendDueDate = (try? values.decode(String.self, forKey: .sendDueDate)) ?? ""
         hidden = (try? values.decode(Bool.self, forKey: .hidden)) ?? false
     }
 }

--- a/WAL/WAL/Screen/Create/Controller/CreateViewController.swift
+++ b/WAL/WAL/Screen/Create/Controller/CreateViewController.swift
@@ -282,7 +282,8 @@ class CreateViewController: UIViewController {
     
     @objc private func touchUpHistoryButton() {
         let historyViewController = HistoryViewController()
-        historyViewController.delegate = self
+        historyViewController.resendWalDelegate = self
+        historyViewController.refreshDelegate = self
         historyViewController.modalPresentationStyle = .overFullScreen
         present(historyViewController, animated: true)
     }
@@ -479,5 +480,11 @@ extension CreateViewController: ResendWalDelegate {
         }
         
         setSendButton()
+    }
+}
+
+extension CreateViewController: RefreshDelegate {
+    func refresh(_ vc: UIViewController) {
+        getReservedDate()
     }
 }

--- a/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
+++ b/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
@@ -308,14 +308,12 @@ extension HistoryViewController: UITableViewDataSource {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: HistoryTableViewCell.cellIdentifier) as? HistoryTableViewCell else { return UITableViewCell() }
             cell.selectionStyle = .none
             cell.setData(sendingData[indexPath.row])
-            selectedIndices.append([-1,-1])
             return cell
         case 1:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: HistoryTableViewCell.cellIdentifier) as? HistoryTableViewCell else { return UITableViewCell() }
             cell.selectionStyle = .none
             cell.hideDdayView()
             cell.setData(completeData[indexPath.row])
-            selectedIndices.append([-1,-1])
             return cell
         default:
             return UITableViewCell()
@@ -341,10 +339,17 @@ extension HistoryViewController {
             }
             if let sendingData = historyData.data?.sendingData {
                 self.sendingData = sendingData
+                for _ in 0 ..< sendingData.count {
+                    self.selectedIndices.append([-1,-1])
+                }
             }
             if let completeData = historyData.data?.completeData {
                 self.completeData = completeData
+                for _ in 0 ..< completeData.count {
+                    self.selectedIndices.append([-1,-1])
+                }
             }
+
             DispatchQueue.main.async {
                 self.historyTableView.reloadData()
             }
@@ -352,18 +357,25 @@ extension HistoryViewController {
     }
     
     func getHistoryInfoAfterDelete() {
+        selectedIndices = []
         HistoryAPI.shared.getHistoryData { historyData, err in
             guard let historyData = historyData else {
                 return
             }
             if let sendingData = historyData.data?.sendingData {
                 self.sendingData = sendingData
+                for _ in 0 ..< sendingData.count {
+                    self.selectedIndices.append([-1,-1])
+                }
             }
             if let completeData = historyData.data?.completeData {
                 self.completeData = completeData
+                for _ in 0 ..< completeData.count {
+                    self.selectedIndices.append([-1,-1])
+                }
             }
+            
             DispatchQueue.main.async {
-                self.selectedIndices = []
                 self.historyTableView.reloadSections(IndexSet(0...1), with: .none)
             }
         }

--- a/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
+++ b/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
@@ -35,7 +35,8 @@ final class HistoryViewController: UIViewController {
     var selectedIndex: IndexPath = []
     var selectedIndices: [IndexPath] = []
     
-    var delegate: ResendWalDelegate?
+    var resendWalDelegate: ResendWalDelegate?
+    var refreshDelegate: RefreshDelegate?
     
     // MARK: - Life Cycle
     
@@ -120,7 +121,10 @@ final class HistoryViewController: UIViewController {
     }
     
     @objc func touchupCloseButton() {
-        dismiss(animated: true)
+        //self.delegate?.resendToCreate(self, walsound: "\(self.completeData[indexPath.row].content)")
+        self.refreshDelegate?.refresh(self)
+        self.presentingViewController?.dismiss(animated: true)
+        //dismiss(animated: true)
     }
     
     func showActionSheet(type: ActionSheetType, postId: Int) {
@@ -229,7 +233,7 @@ extension HistoryViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let resendAction = UIContextualAction(style: .normal, title: "재전송") { (UIContextualAction, UIView, success: @escaping (Bool) -> Void) in
-            self.delegate?.resendToCreate(self, walsound: "\(self.completeData[indexPath.row].content)")
+            self.resendWalDelegate?.resendToCreate(self, walsound: "\(self.completeData[indexPath.row].content)")
             self.presentingViewController?.dismiss(animated: true)
             success(true)
         }

--- a/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
+++ b/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
@@ -316,7 +316,7 @@ extension HistoryViewController: UITableViewDataSource {
         case 1:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: HistoryTableViewCell.cellIdentifier) as? HistoryTableViewCell else { return UITableViewCell() }
             cell.selectionStyle = .none
-            cell.hideDdayView()
+            // cell.hideDdayView()
             cell.setData(completeData[indexPath.row])
             return cell
         default:

--- a/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
+++ b/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
@@ -121,10 +121,8 @@ final class HistoryViewController: UIViewController {
     }
     
     @objc func touchupCloseButton() {
-        //self.delegate?.resendToCreate(self, walsound: "\(self.completeData[indexPath.row].content)")
         self.refreshDelegate?.refresh(self)
         self.presentingViewController?.dismiss(animated: true)
-        //dismiss(animated: true)
     }
     
     func showActionSheet(type: ActionSheetType, postId: Int) {

--- a/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
+++ b/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
@@ -35,8 +35,8 @@ final class HistoryViewController: UIViewController {
     var selectedIndex: IndexPath = []
     var selectedIndices: [IndexPath] = []
     
-    var resendWalDelegate: ResendWalDelegate?
-    var refreshDelegate: RefreshDelegate?
+    weak var resendWalDelegate: ResendWalDelegate?
+    weak var refreshDelegate: RefreshDelegate?
     
     // MARK: - Life Cycle
     

--- a/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
+++ b/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
@@ -104,6 +104,10 @@ final class HistoryViewController: UIViewController {
                         cell.coverView.isHidden = false
                     })
                 default:
+                    let point: CGPoint = sender.location(in: self.historyTableView.cellForRow(at: indexPath))
+                    if point.y > 100 || point.y < 15 {
+                        sender.state = .ended
+                    }
                     selectedIndex = indexPath
                     UIView.animate(withDuration: 0.1, delay: 0, options: [], animations: {
                         self.historyTableView.beginUpdates()

--- a/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
+++ b/WAL/WAL/Screen/History/View/HistoryTableViewCell.swift
@@ -235,7 +235,16 @@ class HistoryTableViewCell: UITableViewCell {
         
         isContentHidden = data.hidden ?? false
         
-        //TODO: 디데이 계산해서 넣어주세요
+        let calendar = Calendar.current
+        let currentDate = Date()
+        var daysCount:Int = 0
+  
+        func days(from date: Date) -> Int {
+            return (calendar.dateComponents([.day], from: currentDate, to: date).day ?? 0) + 1
+        }
+        daysCount = days(from: data.sendDueDate.toDate() ?? currentDate)
+        
+        dDayLabel.text = "D-\(daysCount)"
         
         sendingDateLabel.text = "\(data.sendingDate)"
         


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- ‘숨긴 왈소리’ 꾹 누른채로 아래로 스와이프하면 숨김 기능이 사라져옹 근데 다시 꾹누르면 정상적으로 돌아옵니당
- 히스토리 뷰에서 완료된 왈소리 하나 지우고 위로 올라가려고 스크롤 중이었는데 강종되었어요
- 왈소리 보내기 > 예약완료 뷰 (메인으로 돌아가기 버튼 클릭) > 메인 도착 , 다시 예약뷰 > 히스토리뷰 이 루틴으로 갔을 때는 나가기가 눌려요 근디 바로 메인으로 나가지는 것 이 아니라 예약 완료뷰가 나와요..!
- 히스토리에서 예약된 왈소리(보내는 중)를 지우고 다시 왈소리 맨들기로 돌아가 지운 날짜에 새로 만들기를 하려고 하는데 날짜가 안눌려욤(이미 보낸 날짜로 나옴). 아예 메인으로 돌아갔다가 다시 들어와야 해당 날짜에 왈소리를 보낼 수 가 있어요 → 히스토리에서 예약된 왈소리를 지우고 왈소리 만들기로 갔을 때 바로 해당 날짜가 선택되게 할 수 있을까용
- D-DAY가 잘못계산돼요 (9월5일 내일 전송예정인 왈소린데 D-6으로 나와요)

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 완료에서 디데이 hidden이 지금 이상해요.. 히든 시켰는데 안되서 일단 hidden 풀어놨고 (완료에도 디데이가 뜹니다: 원래 안떠야됨) 나중에 이슈 따로 파서 다시 고쳐보도록하겠습니다

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #57 
