### PR TITLE
[Fix] FcmToken 강제언래핑으로 인해 nil 문제 해결

### DIFF
--- a/WAL/Podfile
+++ b/WAL/Podfile
@@ -7,7 +7,6 @@ target 'WAL' do
 
   # Pods for WAL
 
-  pod 'SnapKit', '~> 5.0.0'
   pod 'Then'
   pod 'Moya', '~> 14.0'
   pod 'KakaoSDKCommon'

--- a/WAL/Podfile.lock
+++ b/WAL/Podfile.lock
@@ -1,28 +1,28 @@
 PODS:
   - Alamofire (5.6.2)
-  - Firebase/CoreOnly (9.4.0):
-    - FirebaseCore (= 9.4.0)
-  - Firebase/Messaging (9.4.0):
+  - Firebase/CoreOnly (9.6.0):
+    - FirebaseCore (= 9.6.0)
+  - Firebase/Messaging (9.6.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 9.4.0)
-  - FirebaseCore (9.4.0):
+    - FirebaseMessaging (~> 9.6.0)
+  - FirebaseCore (9.6.0):
     - FirebaseCoreDiagnostics (~> 9.0)
     - FirebaseCoreInternal (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (9.5.0):
+  - FirebaseCoreDiagnostics (9.6.0):
     - GoogleDataTransport (< 10.0.0, >= 9.1.4)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseCoreInternal (9.5.0):
+  - FirebaseCoreInternal (9.6.0):
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
-  - FirebaseInstallations (9.5.0):
+  - FirebaseInstallations (9.6.0):
     - FirebaseCore (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
     - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (9.4.0):
+  - FirebaseMessaging (9.6.0):
     - FirebaseCore (~> 9.0)
     - FirebaseInstallations (~> 9.0)
     - GoogleDataTransport (< 10.0.0, >= 9.1.4)
@@ -35,36 +35,36 @@ PODS:
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/AppDelegateSwizzler (7.7.0):
+  - GoogleUtilities/AppDelegateSwizzler (7.8.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.7.0):
+  - GoogleUtilities/Environment (7.8.0):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.7.0):
+  - GoogleUtilities/Logger (7.8.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (7.7.0):
+  - GoogleUtilities/Network (7.8.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.7.0)"
-  - GoogleUtilities/Reachability (7.7.0):
+  - "GoogleUtilities/NSData+zlib (7.8.0)"
+  - GoogleUtilities/Reachability (7.8.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.7.0):
+  - GoogleUtilities/UserDefaults (7.8.0):
     - GoogleUtilities/Logger
-  - KakaoSDKAuth (2.11.1):
-    - KakaoSDKCommon (= 2.11.1)
-  - KakaoSDKCommon (2.11.1):
-    - KakaoSDKCommon/Common (= 2.11.1)
-    - KakaoSDKCommon/Network (= 2.11.1)
-  - KakaoSDKCommon/Common (2.11.1)
-  - KakaoSDKCommon/Network (2.11.1):
+  - KakaoSDKAuth (2.11.2):
+    - KakaoSDKCommon (= 2.11.2)
+  - KakaoSDKCommon (2.11.2):
+    - KakaoSDKCommon/Common (= 2.11.2)
+    - KakaoSDKCommon/Network (= 2.11.2)
+  - KakaoSDKCommon/Common (2.11.2)
+  - KakaoSDKCommon/Network (2.11.2):
     - Alamofire (~> 5.1)
-    - KakaoSDKCommon/Common (= 2.11.1)
-  - KakaoSDKUser (2.11.1):
-    - KakaoSDKAuth (= 2.11.1)
+    - KakaoSDKCommon/Common (= 2.11.2)
+  - KakaoSDKUser (2.11.2):
+    - KakaoSDKAuth (= 2.11.2)
   - Kingfisher (7.3.2)
-  - lottie-ios (3.4.2)
+  - lottie-ios (3.4.3)
   - Moya (14.0.0):
     - Moya/Core (= 14.0.0)
   - Moya/Core (14.0.0):
@@ -81,7 +81,6 @@ PODS:
   - RxRelay (6.5.0):
     - RxSwift (= 6.5.0)
   - RxSwift (6.5.0)
-  - SnapKit (5.0.1)
   - Then (3.0.0)
 
 DEPENDENCIES:
@@ -94,7 +93,6 @@ DEPENDENCIES:
   - Moya (~> 14.0)
   - RxCocoa (= 6.5.0)
   - RxSwift (= 6.5.0)
-  - SnapKit (~> 5.0.0)
   - Then
 
 SPEC REPOS:
@@ -119,33 +117,31 @@ SPEC REPOS:
     - RxCocoa
     - RxRelay
     - RxSwift
-    - SnapKit
     - Then
 
 SPEC CHECKSUMS:
   Alamofire: d368e1ff8a298e6dde360e35a3e68e6c610e7204
-  Firebase: 7703fc4022824b6d6db1bf7bea58d13b8e17ec46
-  FirebaseCore: 9a2b10270a854731c4d4d8a97d0aa8380ec3458d
-  FirebaseCoreDiagnostics: 17cbf4e72b1dbd64bfdc33d4b1f07bce4f16f1d8
-  FirebaseCoreInternal: 50a8e39cae8abf72d5145d07ea34c3244f70862b
-  FirebaseInstallations: 41f811b530c41dd90973d0174381cdb3fcb5e839
-  FirebaseMessaging: 4e220eddd356181469ba2ec5f7d5fafbc2312841
+  Firebase: 5ae8b7cf8efce559a653aef0ad95bab3f427c351
+  FirebaseCore: 2082fffcd855f95f883c0a1641133eb9bbe76d40
+  FirebaseCoreDiagnostics: 99a495094b10a57eeb3ae8efa1665700ad0bdaa6
+  FirebaseCoreInternal: bca76517fe1ed381e989f5e7d8abb0da8d85bed3
+  FirebaseInstallations: 0a115432c4e223c5ab20b0dbbe4cbefa793a0e8e
+  FirebaseMessaging: a4d7910e4af663c9cbfc1071c5bef34651690949
   GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
-  GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
-  KakaoSDKAuth: bb2dfa7be30daa8403c9cfc8001aa6fde7a5b779
-  KakaoSDKCommon: 555e1bb46595b842ded01cf7888cc17bbae4e113
-  KakaoSDKUser: 08c0a4f40bebdebdf948a9e3d0e44ed5c2754f99
+  GoogleUtilities: 1d20a6ad97ef46f67bbdec158ce00563a671ebb7
+  KakaoSDKAuth: 98f90fb67b2c2015cc94066a4489d54bb2f2a68e
+  KakaoSDKCommon: 83fef177bcad9a8f9cb728f92e04a464882d3a82
+  KakaoSDKUser: bf7b02e23257199995cdd03d59feb716416d14d6
   Kingfisher: 0086ad83719761ba9b2cdaf6ef4d5b4878cbae23
-  lottie-ios: 6bbc53eef6957e4744a50321507015fba72d8ca6
+  lottie-ios: 9ae750cdc7820fecbd3c2f0cfc493038208fcdc4
   Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
   RxCocoa: 94f817b71c07517321eb4f9ad299112ca8af743b
   RxRelay: 1de1523e604c72b6c68feadedd1af3b1b4d0ecbd
   RxSwift: 5710a9e6b17f3c3d6e40d6e559b9fa1e813b2ef8
-  SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
   Then: 844265ae87834bbe1147d91d5d41a404da2ec27d
 
-PODFILE CHECKSUM: c2f2da79b67c3790fe2bf07b4a23983cbac29bb3
+PODFILE CHECKSUM: 18f68ce9c38692309069cdcaeca1009aa5c19352
 
 COCOAPODS: 1.11.3

--- a/WAL/WAL.xcodeproj/project.pbxproj
+++ b/WAL/WAL.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		5B4A844B2857D3780032287D /* CardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4A844A2857D3780032287D /* CardButton.swift */; };
 		5B567E2128B0FCC300BF9E17 /* NSNotification.Name+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B567E2028B0FCC300BF9E17 /* NSNotification.Name+.swift */; };
 		5B66CF4228E153C8009ED52F /* UserDefaulstHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B66CF4128E153C8009ED52F /* UserDefaulstHelper.swift */; };
+		5B66CF4528E2A3B0009ED52F /* WALKit in Frameworks */ = {isa = PBXBuildFile; productRef = 5B66CF4428E2A3B0009ED52F /* WALKit */; };
+		5B66CF4B28E2A6F9009ED52F /* Gifu in Frameworks */ = {isa = PBXBuildFile; productRef = 5B66CF4A28E2A6F9009ED52F /* Gifu */; };
 		5B7EE87C2822D6FE007BC265 /* BaseTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B7EE87B2822D6FE007BC265 /* BaseTargetType.swift */; };
 		5B7EE87E2822DCB5007BC265 /* MoyaLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B7EE87D2822DCB5007BC265 /* MoyaLoggerPlugin.swift */; };
 		5BA3893227F6B94F0010EAA1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA3893127F6B94F0010EAA1 /* AppDelegate.swift */; };
@@ -85,8 +87,6 @@
 		5BD35864289D482E0066C804 /* ZanzanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD35863289D482E0066C804 /* ZanzanView.swift */; };
 		5BE2E5FC28572C8E0053AF4C /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5BE2E5FB28572C8E0053AF4C /* GoogleService-Info.plist */; };
 		5BECCA8F286A43B800DD70A3 /* MenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BECCA8E286A43B800DD70A3 /* MenuButton.swift */; };
-		5BF3D56828C381D7009663EA /* Gifu in Frameworks */ = {isa = PBXBuildFile; productRef = 5BF3D56728C381D7009663EA /* Gifu */; };
-		5BF3D56B28C381F1009663EA /* WALKit in Frameworks */ = {isa = PBXBuildFile; productRef = 5BF3D56A28C381F1009663EA /* WALKit */; };
 		5BFC216128B920F100E4F65A /* Transition+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFC216028B920F100E4F65A /* Transition+.swift */; };
 		9205E747286EE1A4000F4B6D /* MainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9205E746286EE1A4000F4B6D /* MainService.swift */; };
 		9205E749286EE1AD000F4B6D /* MainAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9205E748286EE1AD000F4B6D /* MainAPI.swift */; };
@@ -248,9 +248,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5BF3D56B28C381F1009663EA /* WALKit in Frameworks */,
+				5B66CF4528E2A3B0009ED52F /* WALKit in Frameworks */,
 				EE5FE777E457C8D83E0EA3AA /* Pods_WAL.framework in Frameworks */,
-				5BF3D56828C381D7009663EA /* Gifu in Frameworks */,
+				5B66CF4B28E2A6F9009ED52F /* Gifu in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -902,8 +902,8 @@
 			);
 			name = WAL;
 			packageProductDependencies = (
-				5BF3D56728C381D7009663EA /* Gifu */,
-				5BF3D56A28C381F1009663EA /* WALKit */,
+				5B66CF4428E2A3B0009ED52F /* WALKit */,
+				5B66CF4A28E2A6F9009ED52F /* Gifu */,
 			);
 			productName = WAL;
 			productReference = 5BA3892E27F6B94F0010EAA1 /* WAL.app */;
@@ -934,8 +934,8 @@
 			);
 			mainGroup = 5BA3892527F6B94F0010EAA1;
 			packageReferences = (
-				5BF3D56628C381D7009663EA /* XCRemoteSwiftPackageReference "Gifu" */,
-				5BF3D56928C381F1009663EA /* XCRemoteSwiftPackageReference "WALKit" */,
+				5B66CF4328E2A3B0009ED52F /* XCRemoteSwiftPackageReference "WALKit" */,
+				5B66CF4928E2A6F9009ED52F /* XCRemoteSwiftPackageReference "Gifu" */,
 			);
 			productRefGroup = 5BA3892F27F6B94F0010EAA1 /* Products */;
 			projectDirPath = "";
@@ -1351,15 +1351,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		5BF3D56628C381D7009663EA /* XCRemoteSwiftPackageReference "Gifu" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/kaishin/Gifu.git";
-			requirement = {
-				kind = exactVersion;
-				version = 3.3.1;
-			};
-		};
-		5BF3D56928C381F1009663EA /* XCRemoteSwiftPackageReference "WALKit" */ = {
+		5B66CF4328E2A3B0009ED52F /* XCRemoteSwiftPackageReference "WALKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/zanzanbari/WALKit.git";
 			requirement = {
@@ -1367,18 +1359,26 @@
 				kind = branch;
 			};
 		};
+		5B66CF4928E2A6F9009ED52F /* XCRemoteSwiftPackageReference "Gifu" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kaishin/Gifu.git";
+			requirement = {
+				kind = exactVersion;
+				version = 3.3.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		5BF3D56728C381D7009663EA /* Gifu */ = {
+		5B66CF4428E2A3B0009ED52F /* WALKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5BF3D56628C381D7009663EA /* XCRemoteSwiftPackageReference "Gifu" */;
-			productName = Gifu;
-		};
-		5BF3D56A28C381F1009663EA /* WALKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5BF3D56928C381F1009663EA /* XCRemoteSwiftPackageReference "WALKit" */;
+			package = 5B66CF4328E2A3B0009ED52F /* XCRemoteSwiftPackageReference "WALKit" */;
 			productName = WALKit;
+		};
+		5B66CF4A28E2A6F9009ED52F /* Gifu */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5B66CF4928E2A6F9009ED52F /* XCRemoteSwiftPackageReference "Gifu" */;
+			productName = Gifu;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/WAL/WAL.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WAL/WAL.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,25 +28,7 @@
           "version": null
         }
       }
-    },
-    {
-      "identity" : "snapkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SnapKit/SnapKit",
-      "state" : {
-        "revision" : "f222cbdf325885926566172f6f5f06af95473158",
-        "version" : "5.6.0"
-      }
-    },
-    {
-      "identity" : "walkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/zanzanbari/WALKit.git",
-      "state" : {
-        "branch" : "develop",
-        "revision" : "40c26700b830b9fbfa927dbcc313b605c22490b2"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/WAL/WAL/Global/Extension/NSNotification.Name+.swift
+++ b/WAL/WAL/Global/Extension/NSNotification.Name+.swift
@@ -9,4 +9,6 @@ import Foundation
 
 extension NSNotification.Name {
     static let changeNickname = NSNotification.Name("changeNickname")
+    static let fcmToken = Notification.Name("FCMToken")
+    static let renewToken = Notification.Name("renewToken")
 }

--- a/WAL/WAL/Global/UserDefaulstHelper.swift
+++ b/WAL/WAL/Global/UserDefaulstHelper.swift
@@ -59,9 +59,9 @@ final class UserDefaultsHelper {
         }
     }
     
-    var fcmtoken: [String: Any]? {
+    var fcmtoken: String? {
         get {
-            return userDefaults.dictionary(forKey: Key.fcmtoken) ?? ["": ""]
+            return userDefaults.string(forKey: Key.fcmtoken)
         }
         set {
             userDefaults.set(newValue, forKey: Key.fcmtoken)
@@ -92,7 +92,6 @@ final class UserDefaultsHelper {
         userDefaults.removeObject(forKey: Key.refreshtoken)
         userDefaults.removeObject(forKey: Key.socialtoken)
         userDefaults.removeObject(forKey: Key.social)
-        userDefaults.removeObject(forKey: Key.fcmtoken)
         userDefaults.removeObject(forKey: Key.nickname)
         userDefaults.removeObject(forKey: Key.complete)
     }

--- a/WAL/WAL/Network/API/Auth/AuthAPI.swift
+++ b/WAL/WAL/Network/API/Auth/AuthAPI.swift
@@ -21,10 +21,10 @@ final class AuthAPI {
     
     // MARK: - POST 소셜로그인
     
-    func postSocialLogin(social: String, socialToken: String, fcmtoken: String?,
+    func postSocialLogin(social: String, socialtoken: String, fcmtoken: String?,
                                 completion: @escaping ((GenericResponse<Login>?, Int?) -> ())) {
         
-        authProvider.request(.social(social: social, socialToken: socialToken, fcmtoken: fcmtoken)) { result in
+        authProvider.request(.social(social: social, socialtoken: socialtoken, fcmtoken: fcmtoken)) { result in
             switch result {
             case .success(let response):
                 do {

--- a/WAL/WAL/Network/API/Auth/AuthAPI.swift
+++ b/WAL/WAL/Network/API/Auth/AuthAPI.swift
@@ -21,7 +21,7 @@ final class AuthAPI {
     
     // MARK: - POST 소셜로그인
     
-    func postSocialLogin(social: String, socialToken: String, fcmtoken: String,
+    func postSocialLogin(social: String, socialToken: String, fcmtoken: String?,
                                 completion: @escaping ((GenericResponse<Login>?, Int?) -> ())) {
         
         authProvider.request(.social(social: social, socialToken: socialToken, fcmtoken: fcmtoken)) { result in

--- a/WAL/WAL/Network/Service/Auth/AuthService.swift
+++ b/WAL/WAL/Network/Service/Auth/AuthService.swift
@@ -8,7 +8,7 @@
 import Moya
 
 enum AuthService {
-    case social(social: String, socialToken: String, fcmtoken: String)
+    case social(social: String, socialToken: String, fcmtoken: String?)
     case logout
     case reissue
     case resign(social: String, param: ResignRequest)
@@ -35,10 +35,16 @@ extension AuthService: BaseTargetType {
     var task: Task {
         switch self {
         case .social(_, let socialToken, let fcmtoken):
-            return .requestParameters(
-                parameters: ["socialtoken": socialToken,
-                             "fcmtoken": fcmtoken],
-                encoding: URLEncoding.queryString)
+            if let fcmtoken = fcmtoken {
+                return .requestParameters(
+                    parameters: ["socialtoken": socialToken,
+                                 "fcmtoken": fcmtoken],
+                    encoding: URLEncoding.queryString)
+            } else {
+                return .requestParameters(
+                    parameters: ["socialtoken": socialToken],
+                    encoding: URLEncoding.queryString)
+            }
         case .logout, .reissue: return .requestPlain
         case .resign(_, let param):
             return .requestJSONEncodable(param)

--- a/WAL/WAL/Network/Service/Auth/AuthService.swift
+++ b/WAL/WAL/Network/Service/Auth/AuthService.swift
@@ -8,7 +8,7 @@
 import Moya
 
 enum AuthService {
-    case social(social: String, socialToken: String, fcmtoken: String?)
+    case social(social: String, socialtoken: String, fcmtoken: String?)
     case logout
     case reissue
     case resign(social: String, param: ResignRequest)
@@ -34,15 +34,15 @@ extension AuthService: BaseTargetType {
     
     var task: Task {
         switch self {
-        case .social(_, let socialToken, let fcmtoken):
+        case .social(_, let socialtoken, let fcmtoken):
             if let fcmtoken = fcmtoken {
                 return .requestParameters(
-                    parameters: ["socialtoken": socialToken,
+                    parameters: ["socialtoken": socialtoken,
                                  "fcmtoken": fcmtoken],
                     encoding: URLEncoding.queryString)
             } else {
                 return .requestParameters(
-                    parameters: ["socialtoken": socialToken],
+                    parameters: ["socialtoken": socialtoken],
                     encoding: URLEncoding.queryString)
             }
         case .logout, .reissue: return .requestPlain

--- a/WAL/WAL/Resource/Support/AppDelegate.swift
+++ b/WAL/WAL/Resource/Support/AppDelegate.swift
@@ -77,13 +77,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 extension AppDelegate: MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-        Messaging.messaging().token { token, error in
+        Messaging.messaging().token { [self] fcmToken, error in
             if let error = error {
                 print("Error fetching FCM registration token: \(error)")
-            } else if let token = token {
-                print("FCM registration token: 💾\(token)")
-                let fcmtoken: [String: String] = ["token": fcmToken ?? ""]
-                UserDefaultsHelper.standard.fcmtoken = fcmtoken
+            } else if let fcmToken = fcmToken {
+                let dataDict: [String: String] = ["token": fcmToken]
+                NotificationCenter.default.post(
+                    name: .fcmToken,
+                    object: nil,
+                    userInfo: dataDict)
+                print("💾 - 푸쉬알림토큰임 : \(fcmToken)")
+                UserDefaultsHelper.standard.fcmtoken = fcmToken
             }
         }
         print("Firebase registration token: \(String(describing: fcmToken))")

--- a/WAL/WAL/Screen/Login/Controller/LoginViewController.swift
+++ b/WAL/WAL/Screen/Login/Controller/LoginViewController.swift
@@ -98,9 +98,9 @@ final class LoginViewController: UIViewController {
     
     // MARK: - Checking Token
     
-    private func setupFcmToken() -> String {
-        guard let fcmtoken = UserDefaultsHelper.standard.fcmtoken else { return String() }
-        return fcmtoken["token"] as! String
+    private func setupFcmToken() -> String? {
+        guard let fcmtoken = UserDefaultsHelper.standard.fcmtoken else { return nil }
+        return fcmtoken["token"] as? String
     }
     
     // MARK: - @objc

--- a/WAL/WAL/Screen/Setting/Controller/SubController/ResignViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SubController/ResignViewController.swift
@@ -112,13 +112,6 @@ final class ResignViewController: UIViewController {
                 if resignData.status < 400 {
                     print("☘️-------회원탈퇴 서버 통신", resignData)
                     UserDefaultsHelper.standard.removeObject()
-                    print("🏓====탈퇴 후 UserDefaults 값들 확인하기====")
-                    print(UserDefaultsHelper.standard.accesstoken)
-                    print(UserDefaultsHelper.standard.refreshtoken)
-                    print(UserDefaultsHelper.standard.social)
-                    print(UserDefaultsHelper.standard.socialtoken)
-                    print(UserDefaultsHelper.standard.nickname)
-                    print("🏓====탈퇴 후 UserDefaults 값들 확인하기====")
                     self.pushToLoginView()
                 } else {
                     print("☘️-------회원 탈퇴 서버 통신 실패로 화면전환 실패")


### PR DESCRIPTION
## 🌱 작업한 내용

- 강제언래핑 문제 해결했습니다.
- podfile에 있는 스냅킷 지우고 walkit에 사용되는 spm의 snapkit을 살려뒀습니다.

## 🌱 PR Point

- 찾아보니까 제가 따로 fcmtoken을 갱신해주는 게 아니라 `앱이 예기치 않게 새 토큰을 얻을 수 있으므로 앱을 시작할 때마다 해당 토큰을 사용자에 대해 기록해야 합니다. 이전 토큰은 더 이상 작동하지 않으며 서버 코드가 오류를 확인하여 언제 제거해야 하는지 확인해야 합니다.
`라고 나와 있더라고요. 그래서 UserDefaults에 초반에 저장해두고 우리 서버 측에서 탈퇴 시에 우리 user 정보 삭제하면 해당 메소드가 호출해서 갱신하는 것이 아닌가 싶습니다. 글구 제가 애플 머시깽이 500에러 뜨는 거는 pushToHome 메소드를 이상한 곳에서 호출해서 그런 것 같습니다.
여튼..

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #35
