### PR TITLE
[Hotfix] 온보딩 화면 전환 및 메인 화면 진입 시 시간대 확인 이슈 해결 (#108)

### DIFF
--- a/WAL/WAL/Network/API/Onboard/OnboardAPI.swift
+++ b/WAL/WAL/Network/API/Onboard/OnboardAPI.swift
@@ -13,7 +13,7 @@ final class OnboardAPI {
     static let shared: OnboardAPI = OnboardAPI()
     private init() { }
     private let onboardProvider = MoyaProvider<OnboardService>(
-        session: Session(interceptor: Interceptor()),
+//        session: Session(interceptor: Interceptor()),
         plugins: [MoyaLoggerPlugin()]
     )
 
@@ -36,7 +36,7 @@ final class OnboardAPI {
                 do {
                     self.onboard = try response.map(UserInfo?.self)
                     guard let onboard = self.onboard else { return }
-                    completion(onboard, nil)
+                    completion(onboard, 201)
                     
                 } catch(let error) {
                     print(error.localizedDescription)

--- a/WAL/WAL/Screen/Main/ViewModel/MainViewModel.swift
+++ b/WAL/WAL/Screen/Main/ViewModel/MainViewModel.swift
@@ -111,15 +111,13 @@ final class MainViewModel {
         case 0:
             guard let intDate = Int(timeFormatter.string(from: date)) else { return }
             
-//            if intDate >= 0 && intDate <= 7 {
-//                output.subTitle.accept("왈뿡이가 자는 시간이에요. 아침에 만나요!")
-//                output.walStatus.accept(.sleeping)
-//            } else {
-//                output.walStatus.accept(.checkedAvailable)
-//            }
+            if intDate >= 0 && intDate <= 7 {
+                output.subTitle.accept("왈뿡이가 자는 시간이에요. 아침에 만나요!")
+                output.walStatus.accept(.sleeping)
+            } else {
+                output.walStatus.accept(.checkedAvailable)
+            }
             
-            // TODO: - Remove
-            output.walStatus.accept(.checkedAvailable)
         default:
             if isShownCount == canOpenCount {
                 output.walStatus.accept(isShownCount == output.todayWalCount.value ? .checkedAll : .checkedAvailable)

--- a/WAL/WAL/Screen/Onboarding/Controller/OnboardingViewController.swift
+++ b/WAL/WAL/Screen/Onboarding/Controller/OnboardingViewController.swift
@@ -163,20 +163,34 @@ extension OnboardingViewController {
                                       time: time) { [weak self] data, status in
             guard let self else { return }
             guard let status = status else { return }
-            if status == 201 {
-                let viewController = OnboardCompleteViewController()
-                // TODO: - 메인 진입할 때
-                UserDefaultsHelper.standard.complete = true
-                UserDefaultsHelper.standard.nickname = nickname
-                self.configureLoadingView()
-                DispatchQueue.main.asyncAfter(deadline: .now()+1) {
-                    self.loadingView.hide()
-                    self.navigationController?.pushViewController(viewController, animated: true)
-                }
-            } else {
+            
+            let networkResult = NetworkResult(rawValue: status) ?? .none
+            
+            switch networkResult {
+            case .created:
+                self.pushToOnboardComplete()
+            case .conflict:
+                self.showToast(message: "이미 온보딩 설정을 완료한 유저입니다.")
+                self.pushToOnboardComplete()
+            default:
                 self.showToast(message: "상태코드: \(status)")
             }
+            
         }
+    }
+    
+    private func pushToOnboardComplete() {
+        let viewController = OnboardCompleteViewController()
+        
+        configureLoadingView()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.loadingView.hide()
+            self.navigationController?.pushViewController(viewController, animated: true)
+        }
+        
+        UserDefaultsHelper.standard.complete = true
+        UserDefaultsHelper.standard.nickname = nickname
     }
 }
 


### PR DESCRIPTION
## 🌱 작업한 내용
- 온보딩 화면 전환 이슈 해결 
- 메인 화면 (00시 ~ 08시) 시간대에 따른 UI 변화 주석 해제 

## 🌱 PR Point
**[ 온보딩 화면 전환 ]**
statusCode를 if 문으로 작성하는 것보다 switch 구문으로 작성하는 것이 좀 더 보기 좋은 것이라 판단했습니다.
또한, switch 구문을 Int로 구분하는 것보다 기존의 상태코드 값에 따른 enum을 만들어 두었기 때문에 
=> NetworkResult를 이용해서 각 네트워크 연결 상태에 따른 화면 전환 또는 토스트 메시지를 띄웠습니다. 

위에 작성된 부분은 OnboardVC를 통해서 확인할 수 있습니다. 

온보딩 API 연결 이후 성공 시 (== 201) 해당 상태코드를 전달하여 VC에서 그에 맞는 핸들링을 할 수 있도록 수정했습니다.


**[ 메인 화면 ]**
메인 화면의 경우 기존의 개발 테스트를 위해서 항상 왈소리를 확인할 수 있는 상태로 처리해 두었지만 실제 같은 테스트를 위해서 시간대에 따른 다른 왈뿡이 캐릭터 + 화면 구조가 변화될 수 있도록 주석 처리를 해제 했습니다.

해당 부분은 MainViewModel을 통해서 확인할 수 있습니다.


## 📮 관련 이슈
- #108 
