### PR TITLE
[Hotfix] API 코드 개선 (#99)

### DIFF
--- a/WAL/WAL.xcodeproj/project.pbxproj
+++ b/WAL/WAL.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		925D13FB29FABF220024F0E5 /* WalCategoryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D13FA29FABF220024F0E5 /* WalCategoryType.swift */; };
 		925D13FD29FABF360024F0E5 /* AlarmTimeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D13FC29FABF360024F0E5 /* AlarmTimeType.swift */; };
 		925D13FF29FAC29B0024F0E5 /* UICollectionViewCell+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D13FE29FAC29B0024F0E5 /* UICollectionViewCell+.swift */; };
+		926480FF2A34BB91007DEC0B /* CustomIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926480FE2A34BB91007DEC0B /* CustomIndicator.swift */; };
 		926A2A132A02A85F005DDCEA /* MainSubtitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926A2A122A02A85F005DDCEA /* MainSubtitle.swift */; };
 		926A2A152A054BF9005DDCEA /* MainSubtitleStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926A2A142A054BF9005DDCEA /* MainSubtitleStatus.swift */; };
 		927519AF29815A6B0010022A /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927519AE29815A6B0010022A /* MainViewModel.swift */; };
@@ -227,6 +228,7 @@
 		925D13FA29FABF220024F0E5 /* WalCategoryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalCategoryType.swift; sourceTree = "<group>"; };
 		925D13FC29FABF360024F0E5 /* AlarmTimeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmTimeType.swift; sourceTree = "<group>"; };
 		925D13FE29FAC29B0024F0E5 /* UICollectionViewCell+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+.swift"; sourceTree = "<group>"; };
+		926480FE2A34BB91007DEC0B /* CustomIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomIndicator.swift; sourceTree = "<group>"; };
 		926A2A122A02A85F005DDCEA /* MainSubtitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSubtitle.swift; sourceTree = "<group>"; };
 		926A2A142A054BF9005DDCEA /* MainSubtitleStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSubtitleStatus.swift; sourceTree = "<group>"; };
 		927519AE29815A6B0010022A /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
@@ -345,6 +347,7 @@
 			isa = PBXGroup;
 			children = (
 				5B3E2C9128E0300A000A7BA4 /* LoadingView.swift */,
+				926480FE2A34BB91007DEC0B /* CustomIndicator.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -1103,6 +1106,7 @@
 				5BB26D30286646AA00257837 /* Reissue.swift in Sources */,
 				5B020D37281EAF020057F9B7 /* String+.swift in Sources */,
 				92B152D02954569800918A3B /* MainTitleView.swift in Sources */,
+				926480FF2A34BB91007DEC0B /* CustomIndicator.swift in Sources */,
 				5BC2DD092868E71700AFCC29 /* MypageViewController.swift in Sources */,
 				5BD17416282CDCDE00C77A95 /* AlarmView.swift in Sources */,
 				E23FF600287FF7B0004016DC /* CreateAPI.swift in Sources */,
@@ -1321,7 +1325,7 @@
 				CODE_SIGN_ENTITLEMENTS = WAL/WAL.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = PU64TS56AD;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WAL/Resource/Support/Info.plist;
@@ -1358,7 +1362,7 @@
 				CODE_SIGN_ENTITLEMENTS = WAL/WAL.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = PU64TS56AD;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WAL/Resource/Support/Info.plist;

--- a/WAL/WAL/Global/Component/CustomIndicator.swift
+++ b/WAL/WAL/Global/Component/CustomIndicator.swift
@@ -1,0 +1,47 @@
+//
+//  IndicatorView.swift
+//  WAL
+//
+//  Created by 소연 on 2023/06/10.
+//
+
+import UIKit
+
+import WALKit
+
+final class CustomIndicator {
+    
+    static func showLoading() {
+        DispatchQueue.main.async {
+            // 최상단 윈도우
+            guard let window = UIApplication.shared.windows.last else { return }
+
+            let loadingIndicatorView: UIActivityIndicatorView
+            
+            // 최상단에 이미 IndicatorView가 있는 경우 그대로 사용
+            if let existedView = window.subviews.first(
+                where: { $0 is UIActivityIndicatorView } ) as? UIActivityIndicatorView {
+                loadingIndicatorView = existedView
+            } else { // 없는 경우 새로 생성
+                loadingIndicatorView = UIActivityIndicatorView(style: .medium)
+                // 로딩이 되는 동안 UI 클릭 방지
+                loadingIndicatorView.frame = window.frame
+                loadingIndicatorView.color = .gray300
+
+                window.addSubview(loadingIndicatorView)
+            }
+            loadingIndicatorView.startAnimating()
+        }
+    }
+
+    static func hideLoading() {
+        DispatchQueue.main.async {
+            guard let window = UIApplication.shared.windows.last else { return }
+            window.subviews.filter({ $0 is UIActivityIndicatorView })
+                .forEach { $0.removeFromSuperview() }
+        }
+    }
+    
+}
+
+

--- a/WAL/WAL/Global/Extension/UIViewController+.swift
+++ b/WAL/WAL/Global/Extension/UIViewController+.swift
@@ -65,6 +65,7 @@ extension UIViewController {
 }
 
 extension UIViewController {
+    /// 로그인 화면으로 이동 (소셜 토큰 만료 등)
     func pushToLoginView() {
         let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
         let sceneDelegate = windowScene?.delegate as? SceneDelegate
@@ -72,5 +73,22 @@ extension UIViewController {
         sceneDelegate?.window?.rootViewController = viewController
         sceneDelegate?.window?.makeKeyAndVisible()
         UserDefaultsHelper.standard.removeAccessToken()
+    }
+}
+
+extension UIViewController {
+    /// 네트워크 연결 유실 시 alert 
+    func showNetworkAlert() {
+        let errorTitle = "네트워크 연결"
+        let errorMsg = "네트워크 연결상태를\n확인 후 다시 시도해 주세요."
+        
+        let alert = UIAlertController(title: errorTitle, message: errorMsg, preferredStyle: .alert)
+        
+        let defaultAction = UIAlertAction(title: "확인", style: .destructive) { _ in
+            exit(0)
+        }
+        
+        alert.addAction(defaultAction)
+        present(alert, animated: true)
     }
 }

--- a/WAL/WAL/Network/API/Auth/AuthAPI.swift
+++ b/WAL/WAL/Network/API/Auth/AuthAPI.swift
@@ -53,7 +53,7 @@ final class AuthAPI {
                     }
                 }
             case .failure(let error):
-                print(error.localizedDescription)
+                print("[소셜로그인] DEBUG: - \(error.localizedDescription)")
                 completion(nil, error.response?.statusCode)
             }
         }
@@ -68,23 +68,10 @@ final class AuthAPI {
         authProvider.request(.resign(param: param)) { result in
             switch result {
             case .success(let response):
-                switch response.statusCode {
-                case 204:
-                    completion(nil, 204)
-                case 300...500:
-                    do {
-                        let defaultData = try response.map(DefaultResponse?.self)
-                        completion(defaultData, nil)
-                    } catch {
-                        print(error.localizedDescription)
-                        completion(nil, 500)
-                    }
-                default:
-                    completion(nil, response.statusCode)
-                }
+                completion(nil, response.statusCode)
             case .failure(let error):
-                print(error.localizedDescription)
-                completion(nil, 500)
+                print("[회원탈퇴] DEBUG: - \(error.localizedDescription)")
+                completion(nil, error.response?.statusCode)
             }
         }
     }
@@ -95,26 +82,19 @@ final class AuthAPI {
         authProvider.request(.reissue) { result in
             switch result {
             case .success(let response):
-                switch response.statusCode {
-                case 200:
-                    guard let accessHeader = response.response?.allHeaderFields[GeneralAPI.authentication] as? String else {
-                        completion(nil, 200)
-                        return
-                    }
-                    let accessToken = String(accessHeader.dropFirst("".count))
-                    UserDefaultsHelper.standard.accesstoken = accessToken
-                    completion(nil, nil)
-                default:
-                    do {
-                        let reissueData = try response.map(DefaultResponse.self)
-                        completion(reissueData, nil)
-                    } catch {
-                        completion(nil, response.statusCode)
-                    }
+                
+                guard let accessHeader = response.response?.allHeaderFields[GeneralAPI.authentication] as? String else {
+                    completion(nil, response.statusCode)
+                    return
                 }
-            case .failure(let err):
-                print(err.localizedDescription)
-                completion(nil, err.response?.statusCode)
+                
+                let accessToken = String(accessHeader.dropFirst("".count))
+                UserDefaultsHelper.standard.accesstoken = accessToken
+                completion(nil, response.statusCode)
+                
+            case .failure(let error):
+                print("[토큰 재발급] DEBUG: - \(error.localizedDescription)")
+                completion(nil, error.response?.statusCode)
             }
         }
     }

--- a/WAL/WAL/Network/API/Auth/AuthAPI.swift
+++ b/WAL/WAL/Network/API/Auth/AuthAPI.swift
@@ -14,7 +14,7 @@ final class AuthAPI {
     static let shared = AuthAPI()
     private init() { }
     private lazy var authProvider = MoyaProvider<AuthService>(
-        session: Session(interceptor: Interceptor()),
+//        session: Session(interceptor: Interceptor()),
         plugins: [MoyaLoggerPlugin()]
     )
 
@@ -98,7 +98,7 @@ final class AuthAPI {
                 switch response.statusCode {
                 case 200:
                     guard let accessHeader = response.response?.allHeaderFields[GeneralAPI.authentication] as? String else {
-                        completion(nil, nil)
+                        completion(nil, 200)
                         return
                     }
                     let accessToken = String(accessHeader.dropFirst("".count))
@@ -109,12 +109,12 @@ final class AuthAPI {
                         let reissueData = try response.map(DefaultResponse.self)
                         completion(reissueData, nil)
                     } catch {
-                        completion(nil, 500)
+                        completion(nil, response.statusCode)
                     }
                 }
             case .failure(let err):
                 print(err.localizedDescription)
-                completion(nil, 500)
+                completion(nil, err.response?.statusCode)
             }
         }
     }

--- a/WAL/WAL/Network/API/Create/CreateAPI.swift
+++ b/WAL/WAL/Network/API/Create/CreateAPI.swift
@@ -14,7 +14,7 @@ final class CreateAPI {
     private init() {}
     
     private let createProvider = MoyaProvider<CreateService>(
-        session: Session(interceptor: Interceptor()),
+//        session: Session(interceptor: Interceptor()),
         plugins: [MoyaLoggerPlugin()]
     )
     

--- a/WAL/WAL/Network/API/History/HistoryAPI.swift
+++ b/WAL/WAL/Network/API/History/HistoryAPI.swift
@@ -13,7 +13,7 @@ final class HistoryAPI {
     static let shared: HistoryAPI = HistoryAPI()
     private init() { }
     private let historyProvider = MoyaProvider<HistoryService>(
-        session: Session(interceptor: Interceptor()),
+//        session: Session(interceptor: Interceptor()),
         plugins: [MoyaLoggerPlugin()]
     )
     

--- a/WAL/WAL/Network/API/History/HistoryAPI.swift
+++ b/WAL/WAL/Network/API/History/HistoryAPI.swift
@@ -21,60 +21,65 @@ final class HistoryAPI {
     public private(set) var cancelHistoryData: DefaultResponse?
     public private(set) var deleteHistoryData: DefaultResponse?
     
-    public func getHistoryData(completion: @escaping ((HistoryResponse?, Int?) -> ())) {
-        historyProvider.request(.history) { result in
+   func getHistoryData(completion: @escaping ((HistoryResponse?, Int?) -> ())) {
+        historyProvider.request(.history) { [weak self] result in
+            guard let _self = self else { return }
+            
             switch result {
             case .success(let response):
                 do {
-                    self.historyData = try response.map(HistoryResponse?.self)
-                    guard let historyData = self.historyData else { return }
-                    completion(historyData, nil)
-                    
-                } catch(let err) {
-                    print(err.localizedDescription, 500)
+                    _self.historyData = try response.map(HistoryResponse?.self)
+                    guard let historyData = _self.historyData else { return }
+                    completion(historyData, response.statusCode)
+                } catch(let error) {
+                    print(error.localizedDescription)
+                    completion(nil, response.statusCode)
                 }
-            case .failure(let err):
-                print(err.localizedDescription)
-                completion(nil, 500)
+            case .failure(let error):
+                print(error.localizedDescription)
+                completion(nil, error.response?.statusCode)
             }
         }
     }
     
-    public func cancelHistoryData(reservationId: Int, completion: @escaping ((DefaultResponse?, Int?) -> ())) {
-        historyProvider.request(.cancelReserve(reservationId: reservationId)) { result in
+    func cancelHistoryData(reservationId: Int, completion: @escaping ((DefaultResponse?, Int?) -> ())) {
+        historyProvider.request(.cancelReserve(reservationId: reservationId)) { [weak self] result in
+            guard let _self = self else { return }
+            
             switch result {
             case .success(let response):
-                print("✅")
                 do {
-                    self.cancelHistoryData = try response.map(DefaultResponse?.self)
-                    guard let cancelHistoryData = self.cancelHistoryData else { return }
-                    completion(cancelHistoryData, nil)
-                    
-                } catch(let err) {
-                    print(err.localizedDescription, 500)
+                    _self.cancelHistoryData = try response.map(DefaultResponse?.self)
+                    guard let cancelHistoryData = _self.cancelHistoryData else { return }
+                    completion(cancelHistoryData, response.statusCode)
+                } catch(let error) {
+                    print(error.localizedDescription)
+                    completion(nil, response.statusCode)
                 }
-            case .failure(let err):
-                print(err.localizedDescription)
-                completion(nil, 500)
+            case .failure(let error):
+                print(error.localizedDescription)
+                completion(nil, error.response?.statusCode)
             }
         }
     }
     
-    public func deleteHistoryData(reservationId: Int, completion: @escaping ((DefaultResponse?, Int?) -> ())) {
-        historyProvider.request(.deleteReserve(reservationId: reservationId)) { result in
+    func deleteHistoryData(reservationId: Int, completion: @escaping ((DefaultResponse?, Int?) -> ())) {
+        historyProvider.request(.deleteReserve(reservationId: reservationId)) { [weak self] result in
+            guard let _self = self else { return }
+            
             switch result {
             case .success(let response):
-                print("✅")
                 do {
-                    self.deleteHistoryData = try response.map(DefaultResponse?.self)
-                    guard let deleteHistoryData = self.deleteHistoryData else { return }
-                    completion(deleteHistoryData, nil)
-                } catch(let err) {
-                    print(err.localizedDescription)
+                    _self.deleteHistoryData = try response.map(DefaultResponse?.self)
+                    guard let deleteHistoryData = _self.deleteHistoryData else { return }
+                    completion(deleteHistoryData, response.statusCode)
+                } catch(let error) {
+                    print(error.localizedDescription)
+                    completion(nil, response.statusCode)
                 }
-            case .failure(let err):
-                print(err.localizedDescription)
-                completion(nil, 500)
+            case .failure(let error):
+                print(error.localizedDescription)
+                completion(nil, error.response?.statusCode)
             }
         }
     }

--- a/WAL/WAL/Network/API/History/HistoryAPI.swift
+++ b/WAL/WAL/Network/API/History/HistoryAPI.swift
@@ -42,44 +42,30 @@ final class HistoryAPI {
         }
     }
     
-    func cancelHistoryData(reservationId: Int, completion: @escaping ((DefaultResponse?, Int?) -> ())) {
+    func cancelHistoryData(reservationId: Int, completion: @escaping ((Void, Int?) -> ())) {
         historyProvider.request(.cancelReserve(reservationId: reservationId)) { [weak self] result in
             guard let _self = self else { return }
             
             switch result {
             case .success(let response):
-                do {
-                    _self.cancelHistoryData = try response.map(DefaultResponse?.self)
-                    guard let cancelHistoryData = _self.cancelHistoryData else { return }
-                    completion(cancelHistoryData, response.statusCode)
-                } catch(let error) {
-                    print(error.localizedDescription)
-                    completion(nil, response.statusCode)
-                }
+                completion((), response.statusCode)
             case .failure(let error):
                 print(error.localizedDescription)
-                completion(nil, error.response?.statusCode)
+                completion((), error.response?.statusCode)
             }
         }
     }
     
-    func deleteHistoryData(reservationId: Int, completion: @escaping ((DefaultResponse?, Int?) -> ())) {
+    func deleteHistoryData(reservationId: Int, completion: @escaping ((Void, Int?) -> ())) {
         historyProvider.request(.deleteReserve(reservationId: reservationId)) { [weak self] result in
             guard let _self = self else { return }
             
             switch result {
             case .success(let response):
-                do {
-                    _self.deleteHistoryData = try response.map(DefaultResponse?.self)
-                    guard let deleteHistoryData = _self.deleteHistoryData else { return }
-                    completion(deleteHistoryData, response.statusCode)
-                } catch(let error) {
-                    print(error.localizedDescription)
-                    completion(nil, response.statusCode)
-                }
+                completion((), response.statusCode)
             case .failure(let error):
                 print(error.localizedDescription)
-                completion(nil, error.response?.statusCode)
+                completion((), error.response?.statusCode)
             }
         }
     }

--- a/WAL/WAL/Network/API/Main/MainAPI.swift
+++ b/WAL/WAL/Network/API/Main/MainAPI.swift
@@ -53,7 +53,6 @@ final class MainAPI {
     func updateMainData(id: Int, completion: @escaping ((Void, Int?) -> ())) {
         
         mainProvider.request(.openTodayWal(todayWalId: id)) { [weak self] result in
-            guard let self = self else { return }
             
             switch result {
             case .success(_):

--- a/WAL/WAL/Network/API/Main/MainAPI.swift
+++ b/WAL/WAL/Network/API/Main/MainAPI.swift
@@ -11,14 +11,12 @@ final class MainAPI {
     static let shared: MainAPI = MainAPI()
     private init() { }
     private let mainProvider = MoyaProvider<MainService>(
-        session: Session(interceptor: Interceptor()),
+//        session: Session(interceptor: Interceptor()),
         plugins: [MoyaLoggerPlugin()]
     )
 
     private(set) var mainData: TodayWalList?
     private(set) var subtitle: MainSubtitle?
-    
-    private var refreshValue = 0
     
     /// 메인 - 오늘의 왈소리 조회
     func getMainData(completion: @escaping ((TodayWalList?, Int?) -> ())) {
@@ -29,36 +27,23 @@ final class MainAPI {
             switch result {
             case .success(let response):
                 do {
-                    
                     self.mainData = try response.map(TodayWalList.self)
                     
                     // 200
                     if let _mainData = self.mainData {
-                        completion(_mainData, nil)
+                        completion(_mainData, 200)
                     } else {
-                        
-                        // 300 ~ 500
-                        if let _statusCase = self.mainData?.statusCase {
-                            switch _statusCase {
-                            case .unAuthorized:
-                                self.getMainData(completion: completion)
-                            default:
-                                return
-                            }
-                            
-                            completion(nil, self.mainData?.statusCode)
-                        }
-                        
+                        completion(nil, response.statusCode)
                     }
                     
                 } catch(let err) {
-                    print(err.localizedDescription, 500)
-                    completion(nil, 500)
+                    print(err.localizedDescription)
+                    completion(nil, response.statusCode)
                 }
                 
             case .failure(let err):
-                print(err.localizedDescription)
-                completion(nil, 500)
+                print("[오늘의 왈소리 조회] DEBUG: - \(err.localizedDescription)")
+                completion(nil, err.response?.statusCode)
             }
         }
         
@@ -71,37 +56,20 @@ final class MainAPI {
             guard let self = self else { return }
             
             switch result {
-            case .success(let response):
-                do {
-                    
-                    // 300 ~ 500
-                    if let _statusCase = self.mainData?.statusCase {
-                        switch _statusCase {
-                        case .unAuthorized:
-                            self.updateMainData(id: id, completion: completion)
-                        default:
-                            return
-                        }
-                    }
-                    
-                    completion((), nil)
-                    
-                    
-                } catch(let err) {
-                    print(err.localizedDescription, 500)
-                    completion((), 500)
-                }
+            case .success(_):
+                completion((), 200)
                 
             case .failure(let err):
-                print(err.localizedDescription)
-                completion((), 500)
+                print("[오늘의 왈소리 확인] DEBUG: - \(err.localizedDescription)")
+                completion((), err.response?.statusCode)
             }
+            
         }
         
     }
     
     /// 메인 - 서브타이틀 조회
-    func getMainSubtitle(completion: @escaping ((MainSubtitle?, NetworkResult?) -> ())) {
+    func getMainSubtitle(completion: @escaping ((MainSubtitle?, Int?) -> ())) {
         
         mainProvider.request(.subtitle) { [weak self] result in
             guard let self = self else { return }
@@ -109,36 +77,16 @@ final class MainAPI {
             switch result {
             case .success(let response):
                 do {
-                    
                     self.subtitle = try response.map(MainSubtitle.self)
-                    
-                    // 200
-                    if let _subtitle = self.subtitle {
-                        completion(_subtitle, nil)
-                    } else {
-                        
-                        // 300 ~ 500
-                        if let _statusCase = self.subtitle?.statusCase {
-                            switch _statusCase {
-                            case .unAuthorized:
-                                self.getMainSubtitle(completion: completion)
-                            default:
-                                return
-                            }
-                            
-                            completion(nil, _statusCase)
-                        }
-                        
-                    }
-                    
+                    completion(self.subtitle, 200)
                 } catch(let err) {
-                    print(err.localizedDescription, 500)
-                    completion(nil, NetworkResult.internalServerError)
+                    print(err.localizedDescription)
+                    completion(nil, response.statusCode)
                 }
                 
             case .failure(let err):
-                print(err.localizedDescription)
-                completion(nil, NetworkResult.internalServerError)
+                print("[서브 타이틀 조회] DEBUG: - \(err.localizedDescription)")
+                completion(nil, err.response?.statusCode)
             }
         }
         

--- a/WAL/WAL/Network/API/Main/MainAPI.swift
+++ b/WAL/WAL/Network/API/Main/MainAPI.swift
@@ -22,7 +22,7 @@ final class MainAPI {
     func getMainData(completion: @escaping ((TodayWalList?, Int?) -> ())) {
         
         mainProvider.request(.todayWal) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             
             switch result {
             case .success(let response):
@@ -52,7 +52,7 @@ final class MainAPI {
     /// 메인 - 오늘의 왈소리 확인
     func updateMainData(id: Int, completion: @escaping ((Void, Int?) -> ())) {
         
-        mainProvider.request(.openTodayWal(todayWalId: id)) { [weak self] result in
+        mainProvider.request(.openTodayWal(todayWalId: id)) { result in
             
             switch result {
             case .success(_):
@@ -71,7 +71,7 @@ final class MainAPI {
     func getMainSubtitle(completion: @escaping ((MainSubtitle?, Int?) -> ())) {
         
         mainProvider.request(.subtitle) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             
             switch result {
             case .success(let response):

--- a/WAL/WAL/Network/API/Main/MainAPI.swift
+++ b/WAL/WAL/Network/API/Main/MainAPI.swift
@@ -36,14 +36,14 @@ final class MainAPI {
                         completion(nil, response.statusCode)
                     }
                     
-                } catch(let err) {
-                    print(err.localizedDescription)
+                } catch(let error) {
+                    print(error.localizedDescription)
                     completion(nil, response.statusCode)
                 }
                 
-            case .failure(let err):
-                print("[오늘의 왈소리 조회] DEBUG: - \(err.localizedDescription)")
-                completion(nil, err.response?.statusCode)
+            case .failure(let error):
+                print("[오늘의 왈소리 조회] DEBUG: - \(error.localizedDescription)")
+                completion(nil, error.response?.statusCode)
             }
         }
         
@@ -58,9 +58,9 @@ final class MainAPI {
             case .success(_):
                 completion((), 200)
                 
-            case .failure(let err):
-                print("[오늘의 왈소리 확인] DEBUG: - \(err.localizedDescription)")
-                completion((), err.response?.statusCode)
+            case .failure(let error):
+                print("[오늘의 왈소리 확인] DEBUG: - \(error.localizedDescription)")
+                completion((), error.response?.statusCode)
             }
             
         }
@@ -78,14 +78,14 @@ final class MainAPI {
                 do {
                     self.subtitle = try response.map(MainSubtitle.self)
                     completion(self.subtitle, 200)
-                } catch(let err) {
-                    print(err.localizedDescription)
+                } catch(let error) {
+                    print(error.localizedDescription)
                     completion(nil, response.statusCode)
                 }
                 
-            case .failure(let err):
-                print("[서브 타이틀 조회] DEBUG: - \(err.localizedDescription)")
-                completion(nil, err.response?.statusCode)
+            case .failure(let error):
+                print("[서브 타이틀 조회] DEBUG: - \(error.localizedDescription)")
+                completion(nil, error.response?.statusCode)
             }
         }
         

--- a/WAL/WAL/Network/API/Setting/SettingAPI.swift
+++ b/WAL/WAL/Network/API/Setting/SettingAPI.swift
@@ -13,7 +13,7 @@ final class SettingAPI {
     static let shared = SettingAPI()
     private init() { }
     private let settingProvider = MoyaProvider<SettingService>(
-        session: Session(interceptor: Interceptor()),
+//        session: Session(interceptor: Interceptor()),
         plugins: [MoyaLoggerPlugin()]
     )
     

--- a/WAL/WAL/Network/Utility/NetworkResult.swift
+++ b/WAL/WAL/Network/Utility/NetworkResult.swift
@@ -8,18 +8,30 @@
 import Foundation
 
 enum NetworkResult: Int {
-    case none = -999
+    case none                   = -999
     
-    case okay = 200
-    case created = 201
-    case noContent = 204
-    case badRequest = 400
-    case unAuthorized = 401
-    case nullValue = 402
-    case forbidden = 403
-    case notFound = 404
-    case conflict = 409
-    case internalServerError = 500
-    case serviceUnavailable = 503
-    case dbError = 600
+    /// 성공 200
+    case okay                   = 200
+    /// 생성 201
+    case created                = 201
+    /// 204
+    case noContent              = 204
+    /// 400
+    case badRequest             = 400
+    /// 401 (토큰만료)
+    case unAuthorized           = 401
+    /// 402
+    case nullValue              = 402
+    /// 403
+    case forbidden              = 403
+    /// 404 (User X)
+    case notFound               = 404
+    /// 409
+    case conflict               = 409
+    /// 5000
+    case internalServerError    = 500
+    /// 503
+    case serviceUnavailable     = 503
+    /// 600
+    case dbError                = 600
 }

--- a/WAL/WAL/Screen/Create/View/CreateViewController.swift
+++ b/WAL/WAL/Screen/Create/View/CreateViewController.swift
@@ -519,7 +519,8 @@ extension CreateViewController {
     }
 }
 
-//MARK: - Protocol
+// MARK: - Protocol
+
 extension CreateViewController: ResendWalDelegate {
     func resendToCreate(_ vc: UIViewController, walsound: String) {
         walSoundTextView.text = walsound

--- a/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
+++ b/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
@@ -456,9 +456,7 @@ extension HistoryViewController {
             
             let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
             switch networkResult {
-            case .okay:
-                guard let cancelHistoryData = cancelHistoryData else { return }
-                print("[cancelHistoryData] DEBUG: - \(cancelHistoryData)")
+            case .noContent:
                 self.getHistoryInfoAfterDelete()
             default:
                 self.showToast(message: "Error: \(_statusCode)")
@@ -474,9 +472,7 @@ extension HistoryViewController {
             
             let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
             switch networkResult {
-            case .okay:
-                guard let deleteHistoryData = deleteHistoryData else { return }
-                print("[deleteHistoryData] DEBUG: - \(deleteHistoryData)")
+            case .noContent:
                 self.getHistoryInfoAfterDelete()
             default:
                 self.showToast(message: "Error: \(_statusCode)")

--- a/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
+++ b/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
@@ -381,72 +381,107 @@ extension HistoryViewController: HistoryCompleteHeaderViewDelegate {
 
 extension HistoryViewController {
     func getHistoryInfo() {
-        HistoryAPI.shared.getHistoryData { historyData, err in
-            guard let historyData = historyData else {
-                return
-            }
-            if let sendingData = historyData.notDoneData {
-                self.sendingData = sendingData
-                for _ in 0 ..< sendingData.count {
-                    self.selectedIndices.append([-1,-1])
+        HistoryAPI.shared.getHistoryData { [weak self] historyData, statusCode in
+            guard let self else { return }
+            guard let _statusCode = statusCode else { return }
+            
+            let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
+            switch networkResult {
+            case .okay:
+                guard let historyData = historyData else { return }
+                
+                if let sendingData = historyData.notDoneData {
+                    self.sendingData = sendingData
+                    for _ in 0 ..< sendingData.count {
+                        self.selectedIndices.append([-1,-1])
+                    }
                 }
-            }
-            if let completeData = historyData.doneData {
-                self.completeData = completeData
-                for _ in 0 ..< completeData.count {
-                    self.selectedIndices.append([-1,-1])
+                
+                if let completeData = historyData.doneData {
+                    self.completeData = completeData
+                    for _ in 0 ..< completeData.count {
+                        self.selectedIndices.append([-1,-1])
+                    }
                 }
+                
+                DispatchQueue.main.async {
+                    self.checkHistoryData()
+                    self.historyTableView.reloadData()
+                }
+                
+            default:
+                self.showToast(message: "Error: \(_statusCode)")
             }
-            DispatchQueue.main.async {
-                self.checkHistoryData()
-                self.historyTableView.reloadData()
-            }
+            
         }
     }
     
     func getHistoryInfoAfterDelete() {
         selectedIndices = []
-        HistoryAPI.shared.getHistoryData { historyData, err in
-            guard let historyData = historyData else {
-                return
-            }
-            if let sendingData = historyData.notDoneData {
-                self.sendingData = sendingData
-                for _ in 0 ..< sendingData.count {
-                    self.selectedIndices.append([-1,-1])
-                }
-            }
-            if let completeData = historyData.doneData {
-                self.completeData = completeData
-                for _ in 0 ..< completeData.count {
-                    self.selectedIndices.append([-1,-1])
-                }
-            }
+        HistoryAPI.shared.getHistoryData { [weak self] historyData, statusCode in
+            guard let self else { return }
+            guard let _statusCode = statusCode else { return }
             
-            DispatchQueue.main.async {
-                self.checkHistoryData()
-                self.historyTableView.reloadSections(IndexSet(0...1), with: .none)
+            let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
+            switch networkResult {
+            case .okay:
+                guard let historyData = historyData else { return }
+                if let sendingData = historyData.notDoneData {
+                    self.sendingData = sendingData
+                    for _ in 0 ..< sendingData.count {
+                        self.selectedIndices.append([-1,-1])
+                    }
+                }
+                if let completeData = historyData.doneData {
+                    self.completeData = completeData
+                    for _ in 0 ..< completeData.count {
+                        self.selectedIndices.append([-1,-1])
+                    }
+                }
+                
+                DispatchQueue.main.async {
+                    self.checkHistoryData()
+                    self.historyTableView.reloadSections(IndexSet(0...1), with: .none)
+                }
+            default:
+                self.showToast(message: "Error: \(_statusCode)")
             }
         }
     }
     
     func cancelHistoryInfo(reservationId: Int) {
-        HistoryAPI.shared.cancelHistoryData(reservationId: reservationId) { cancelHistoryData, err in
-            guard let cancelHistoryData = cancelHistoryData else {
-                return
+        HistoryAPI.shared.cancelHistoryData(reservationId: reservationId) { [weak self] cancelHistoryData, statusCode in
+            guard let self else { return }
+            guard let _statusCode = statusCode else { return }
+            
+            let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
+            switch networkResult {
+            case .okay:
+                guard let cancelHistoryData = cancelHistoryData else { return }
+                print("[cancelHistoryData] DEBUG: - \(cancelHistoryData)")
+                self.getHistoryInfoAfterDelete()
+            default:
+                self.showToast(message: "Error: \(_statusCode)")
             }
-            print(cancelHistoryData)
-            self.getHistoryInfoAfterDelete()
+            
         }
     }
     
     func deleteHistoryInfo(reservationId: Int) {
-        HistoryAPI.shared.deleteHistoryData(reservationId: reservationId) { deleteHistoryData, err in
-            guard let deleteHistoryData = deleteHistoryData else {
-                return
+        HistoryAPI.shared.deleteHistoryData(reservationId: reservationId) { [weak self] deleteHistoryData, statusCode in
+            guard let self else { return }
+            guard let _statusCode = statusCode else { return }
+            
+            let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
+            switch networkResult {
+            case .okay:
+                guard let deleteHistoryData = deleteHistoryData else { return }
+                print("[deleteHistoryData] DEBUG: - \(deleteHistoryData)")
+                self.getHistoryInfoAfterDelete()
+            default:
+                self.showToast(message: "Error: \(_statusCode)")
             }
-            print(deleteHistoryData)
-            self.getHistoryInfoAfterDelete()
         }
     }
+    
 }

--- a/WAL/WAL/Screen/Login/Controller/LoginViewController.swift
+++ b/WAL/WAL/Screen/Login/Controller/LoginViewController.swift
@@ -142,17 +142,20 @@ final class LoginViewController: UIViewController {
 extension LoginViewController {
     private func postLogin(socialToken: String, socialType: SocialType, fcmToken: String) {
         let param = LoginRequest(socialToken, socialType.rawValue, fcmToken)
-        AuthAPI.shared.postLogin(param: param) { [weak self] ( data, status) in
+        AuthAPI.shared.postLogin(param: param) { [weak self] (data, statusCode) in
             guard let self = self else { return }
-            guard let status = status else { return }
-            self.showToast(message: "상태코드: \(status)")
-            if status == 403 {
+            guard let _statusCode = statusCode else { return }
+            
+            let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
+            
+            switch networkResult {
+            case .forbidden:
                 self.showAlert(title: Constant.Login.resign,
                                message: nil,
                                actions: [],
                                cancelTitle: "확인",
                                preferredStyle: .alert)
-            } else {
+            default:
                 UserDefaultsHelper.standard.socialtoken = socialToken
                 UserDefaultsHelper.standard.social = socialType.rawValue
                 self.pushToHome()

--- a/WAL/WAL/Screen/Main/Controller/MainViewController.swift
+++ b/WAL/WAL/Screen/Main/Controller/MainViewController.swift
@@ -84,6 +84,8 @@ final class MainViewController: UIViewController {
     private let viewModel: MainViewModel
     private let disposeBag = DisposeBag()
     
+    typealias ErrorInfo<T> = (error: Error, type: T?)
+    
     // MARK: - Initializer
     
     init(viewModel: MainViewModel) {
@@ -116,6 +118,7 @@ final class MainViewController: UIViewController {
         rxBindOutput()
         rxBindView()
         rxBindInput()
+//        rxBindOutputError()
     }
     
     // MARK: - Init UI
@@ -300,6 +303,26 @@ final class MainViewController: UIViewController {
     private func rxBindInput() {
         viewModel.input.reqTodayWal.accept(())
         viewModel.input.reqSubtitle.accept(())
+    }
+    
+    private func rxBindOutputError() {
+        viewModel.errorResult.reqTodayWal
+            .do(onNext: { networkResult in
+                CustomIndicator.showLoading()
+            })
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, networkResult in
+                
+                switch networkResult {
+                case .okay:
+                    CustomIndicator.hideLoading()
+                default:
+                    break
+                }
+                
+                owner.showToast(message: "\(networkResult) error")
+            }
+            .disposed(by: disposeBag)
     }
     
     // MARK: - Custom Method

--- a/WAL/WAL/Screen/Main/Controller/MainViewController.swift
+++ b/WAL/WAL/Screen/Main/Controller/MainViewController.swift
@@ -241,12 +241,28 @@ final class MainViewController: UIViewController {
             .disposed(by: disposeBag)
         
         viewModel.output.openWal
-            .bind(with: self) { owner, res in
-                if let _res = res {
-                    // TODO: 상태코드 별 분기처리 (error)
-                } else {
+            .compactMap { NetworkResult(rawValue: $0) ?? NetworkResult.none }
+            .bind(with: self) { owner, networkResult in
+                
+                switch networkResult {
+                case .okay:
                     owner.todayWalList[owner.selectedItemIndex].showStatus = "OPEN"
                     owner.viewModel.handleWalState(todayWalList: owner.todayWalList)
+                default:
+                    owner.showToast(message: "Error : \(networkResult)")
+                }
+                
+            }
+            .disposed(by: disposeBag)
+        
+        viewModel.output.socialTokenExpired
+            .bind(with: self) { owner, expired in
+                switch expired {
+                case true:
+                    // 소셜토큰이 만료 > 로그인 화면으로 이동 (재로그인)
+                    owner.pushToLoginView()
+                case false:
+                    break
                 }
             }
             .disposed(by: disposeBag)
@@ -392,7 +408,7 @@ extension MainViewController: UICollectionViewDelegateFlowLayout, UICollectionVi
         if !showStatus {
             guard let _todayWalId = todayWalList[indexPath.item].todayWalId else { return }
             selectedItemIndex = indexPath.item
-            viewModel.input.reqOpenWal.accept(_todayWalId)
+            viewModel.input.reqTodayWalOpen.accept(_todayWalId)
         }
         
     }

--- a/WAL/WAL/Screen/Main/ViewModel/MainViewModel.swift
+++ b/WAL/WAL/Screen/Main/ViewModel/MainViewModel.swift
@@ -202,9 +202,9 @@ extension MainViewModel {
             case .unAuthorized:
                 _self.requestRefreshToken(requestType: .todayWal, id: nil)
             default:
-                _self.errorResult.reqTodayWal.accept(networkResult)
                 print("[MAIN] DEBUG: - \(_statusCode)")
             }
+            _self.errorResult.reqTodayWal.accept(networkResult)
         }
     }
     

--- a/WAL/WAL/Screen/Main/ViewModel/MainViewModel.swift
+++ b/WAL/WAL/Screen/Main/ViewModel/MainViewModel.swift
@@ -56,7 +56,7 @@ final class MainViewModel {
             }
             .disposed(by: disposeBag)
         
-        input.reqOpenWal
+        input.reqTodayWalOpen
             .bind(with: self) { owner, res in
                 owner.requestOpenWal(id: res)
             }
@@ -111,12 +111,15 @@ final class MainViewModel {
         case 0:
             guard let intDate = Int(timeFormatter.string(from: date)) else { return }
             
-            if intDate >= 0 && intDate <= 7 {
-                output.subTitle.accept("왈뿡이가 자는 시간이에요. 아침에 만나요!")
-                output.walStatus.accept(.sleeping)
-            } else {
-                output.walStatus.accept(.checkedAvailable)
-            }
+//            if intDate >= 0 && intDate <= 7 {
+//                output.subTitle.accept("왈뿡이가 자는 시간이에요. 아침에 만나요!")
+//                output.walStatus.accept(.sleeping)
+//            } else {
+//                output.walStatus.accept(.checkedAvailable)
+//            }
+            
+            // TODO: - REMOVE
+            output.walStatus.accept(.checkedAvailable)
             
         default:
             if isShownCount == canOpenCount {
@@ -170,40 +173,109 @@ final class MainViewModel {
     
 }
 
-// MARK: - API Request
+// MARK: - Enums
 
 extension MainViewModel {
     
+    enum MainRequestType {
+        case todayWal
+        case todayWalOpen
+        case subtitle
+    }
+    
+}
+
+// MARK: - API Request
+
+extension MainViewModel {
+    /// 오늘의 왈소리 GET
     private func requestTodayWal() {
         MainAPI.shared.getMainData { [weak self] mainData, statusCode in
-            guard let self = self else { return }
-            guard let _todayWalInfo = mainData?.todayWalInfo else { return }
+            guard let _self = self else { return }
+            guard let _statusCode = statusCode else { return }
             
-            self.output.todayWal.accept(_todayWalInfo)
-            self.output.todayWalCount.accept(_todayWalInfo.count)
-            self.handleWalState(todayWalList: _todayWalInfo)
+            let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
+            switch networkResult {
+            case .okay:
+                guard let _todayWalInfo = mainData?.todayWalInfo else { return }
+                _self.output.todayWal.accept(_todayWalInfo)
+                _self.output.todayWalCount.accept(_todayWalInfo.count)
+                _self.handleWalState(todayWalList: _todayWalInfo)
+            case .unAuthorized:
+                _self.requestRefreshToken(requestType: .todayWal, id: nil)
+            default:
+                print("[MAIN] DEBUG: - \(_statusCode)")
+            }
         }
     }
     
+    /// 왈소리 확인 PATCH
     private func requestOpenWal(id: Int) {
         MainAPI.shared.updateMainData(id: id) { [weak self] _, statusCode in
-            guard let self = self else { return }
-            self.output.openWal.accept(statusCode)
+            guard let _self = self else { return }
+            guard let _statusCode = statusCode else { return }
+            
+            let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
+            switch networkResult {
+            case .okay:
+                _self.output.openWal.accept(_statusCode)
+            case .unAuthorized:
+                _self.requestRefreshToken(requestType: .todayWalOpen, id: nil)
+            default:
+                print("[MAIN] DEBUG: - \(_statusCode)")
+            }
         }
     }
     
+    /// 오늘의 서브타이틀 GET
     private func requestSubtitle() {
-        MainAPI.shared.getMainSubtitle { [weak self] subtitle, statusCase in
-            guard let self = self else { return }
+        MainAPI.shared.getMainSubtitle { [weak self] subtitle, statusCode in
+            guard let _self = self else { return }
             guard let _subtitle = subtitle?.todaySubtitle else { return }
+            guard let _statusCode = statusCode else { return }
             
-            guard let _statusCase = statusCase else {
-                self.setSubtitleToUserDefaults(date: Date(), subtitle: _subtitle)
-                self.output.subTitle.accept(_subtitle)
-                return
+            let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
+            switch networkResult {
+            case .okay:
+                _self.setSubtitleToUserDefaults(date: Date(), subtitle: _subtitle)
+                _self.output.subTitle.accept(_subtitle)
+            case .unAuthorized:
+                _self.requestRefreshToken(requestType: .subtitle, id: nil)
+            default:
+                print("[MAIN] DEBUG: - \(_statusCode)")
             }
+        }
+    }
+    
+    /// 토큰만료 시 재발급
+    private func requestRefreshToken(requestType: MainRequestType, id: Int?) {
+        AuthAPI.shared.postReissue { [weak self] response, statusCode in
+            guard let _self = self else { return }
+            guard let _statusCode = statusCode else { return }
             
-            
+            let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
+            switch networkResult {
+            case .okay:
+                // 재발급 성공 시 다시 함수 호출
+                _self.requestAPI(requestType: requestType, id: id)
+            case .unAuthorized:
+                // 소셜 토큰 만료 시 로그인 화면으로 이동
+                _self.output.socialTokenExpired.accept(true)
+            default:
+                break
+            }
+        }
+    }
+    
+    private func requestAPI(requestType: MainRequestType, id: Int?) {
+        switch requestType {
+        case .todayWal:
+            requestTodayWal()
+        case .todayWalOpen:
+            guard let _id = id else { return }
+            requestOpenWal(id: _id)
+        case .subtitle:
+            requestSubtitle()
         }
     }
     
@@ -214,15 +286,17 @@ extension MainViewModel {
 extension MainViewModel {
     
     enum Error {
+        case reqTodayWal
+        case reqTodayWalOpen
         case reqSubtitle
     }
     
     struct Input {
         let reqTodayWal = PublishRelay<Void>()
-        let reqImageUrl = PublishRelay<(UIImage, String)>()
-        let reqOpenWal = PublishRelay<Int>()
-        let checkTime = PublishRelay<Int>()
+        let reqTodayWalOpen = PublishRelay<Int>()
         let reqSubtitle = PublishRelay<Void>()
+        let reqImageUrl = PublishRelay<(UIImage, String)>()
+        let checkTime = PublishRelay<Int>()
     }
     
     struct Output {
@@ -230,8 +304,11 @@ extension MainViewModel {
         let todayWalCount = BehaviorRelay<Int>(value: 0)
         let subTitle = BehaviorRelay<String>(value: "")
         let walStatus = PublishRelay<WalStatus>()
+        let openWal = PublishRelay<Int>()
         let imageUrl = PublishRelay<URL?>()
-        let openWal = PublishRelay<Int?>()
+        
+        /// 소셜 토큰 만료 시
+        let socialTokenExpired = PublishRelay<Bool>()
     }
     
 }

--- a/WAL/WAL/Screen/Main/ViewModel/MainViewModel.swift
+++ b/WAL/WAL/Screen/Main/ViewModel/MainViewModel.swift
@@ -16,6 +16,7 @@ final class MainViewModel {
     
     private(set) var input = Input()
     private(set) var output = Output()
+    private(set) var errorResult = ErrorResult()
     
     // MARK: - Properties
     
@@ -111,15 +112,12 @@ final class MainViewModel {
         case 0:
             guard let intDate = Int(timeFormatter.string(from: date)) else { return }
             
-//            if intDate >= 0 && intDate <= 7 {
-//                output.subTitle.accept("왈뿡이가 자는 시간이에요. 아침에 만나요!")
-//                output.walStatus.accept(.sleeping)
-//            } else {
-//                output.walStatus.accept(.checkedAvailable)
-//            }
-            
-            // TODO: - REMOVE
-            output.walStatus.accept(.checkedAvailable)
+            if intDate >= 0 && intDate <= 7 {
+                output.subTitle.accept("왈뿡이가 자는 시간이에요. 아침에 만나요!")
+                output.walStatus.accept(.sleeping)
+            } else {
+                output.walStatus.accept(.checkedAvailable)
+            }
             
         default:
             if isShownCount == canOpenCount {
@@ -204,6 +202,7 @@ extension MainViewModel {
             case .unAuthorized:
                 _self.requestRefreshToken(requestType: .todayWal, id: nil)
             default:
+                _self.errorResult.reqTodayWal.accept(networkResult)
                 print("[MAIN] DEBUG: - \(_statusCode)")
             }
         }
@@ -285,10 +284,10 @@ extension MainViewModel {
 
 extension MainViewModel {
     
-    enum Error {
-        case reqTodayWal
-        case reqTodayWalOpen
-        case reqSubtitle
+    struct ErrorResult {
+        let reqTodayWal = PublishRelay<NetworkResult>()
+        let reqTodayWalOpen = PublishRelay<NetworkResult>()
+        let reqSubtitle = PublishRelay<NetworkResult>()
     }
     
     struct Input {

--- a/WAL/WAL/Screen/Onboarding/Controller/OnboardingViewController.swift
+++ b/WAL/WAL/Screen/Onboarding/Controller/OnboardingViewController.swift
@@ -160,11 +160,11 @@ extension OnboardingViewController {
     private func postOnboard() {
         OnboardAPI.shared.postOnboard(nickname: nickname,
                                       category: category,
-                                      time: time) { [weak self] data, status in
+                                      time: time) { [weak self] data, statusCode in
             guard let self else { return }
-            guard let status = status else { return }
+            guard let _statusCode = statusCode else { return }
             
-            let networkResult = NetworkResult(rawValue: status) ?? .none
+            let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
             
             switch networkResult {
             case .created:
@@ -173,7 +173,7 @@ extension OnboardingViewController {
                 self.showToast(message: "이미 온보딩 설정을 완료한 유저입니다.")
                 self.pushToOnboardComplete()
             default:
-                self.showToast(message: "상태코드: \(status)")
+                self.showToast(message: "Error: \(_statusCode)")
             }
             
         }

--- a/WAL/WAL/Screen/Setting/Controller/SubController/ResignViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SubController/ResignViewController.swift
@@ -110,14 +110,20 @@ final class ResignViewController: UIViewController {
 extension ResignViewController {
     private func postResign() {
         let param = ResignRequest(reasons: reasonData)
-        AuthAPI.shared.postResign(param: param) { [weak self] (resignData, status) in
+        AuthAPI.shared.postResign(param: param) { [weak self] (resignData, statusCode) in
             guard let self else { return }
-            guard let status = status else { return }
-            if status == 204 {
-                print("탈퇴성공")
+            guard let _statusCode = statusCode else { return }
+            
+            let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
+            
+            switch networkResult {
+            case .noContent:
                 self.pushToLoginView()
                 UserDefaultsHelper.standard.removeObject()
+            default:
+                self.showToast(message: "Error: \(_statusCode)")
             }
+            
         }
     }
 }


### PR DESCRIPTION
## 🌱 작업한 내용
**[ statusCode ]**
- BaseTargetType에 200번대의 성공 시에만 .success 구문을 타도록 설정해 두었습니다.
- 그렇기 때문에 그 외의 300 ~ 600 번대의 상태코드는 모두 .failure 구문을 탑니다.
- 이 때 API와 VC(또는 VM)에서 상태코드를 핸들링하는 로직이 각 API 별로 상이했기 때문에 이를 하나의 컨벤션으로 수정했습니다.

_(기존)_
어떤 API는 상태코드를 넘기기도 하고 어떤 API는 nil을 넘기기도 하고, 어떤 API에서는 (enum으로 만들어 두었던)NetworkResult로 넘겼습니다. 
_(변경)_
제가 설정한 컨벤션은 다음과 같습니다.
1. API에서는 어떤 상태여도(성공이든, 실패이든) VC 또는 VM에서 해당 상태코드에 맞는 핸들링이 필요하기 때문에 completion으로 statusCode를 함께 넘깁니다.
2. API를 호출한 곳에서 Int형의 상태코드를 enum으로 만들어 두었던 NetworkResult를 이용해 (ex, `NetworkResult(rawValue: statusCode)` ) switch 구문과 함께 사용하여 각 상황에 대한 핸들링을 합니다.
-> 여기서 if문이 아닌, switch 구문을 사용한 이유는 코드의 가독성과 컴파일 향상 두가지 이유가 있습니다.


**[ Interceptor ]**
- 기존의 인터셉터가 retryCount로 제한을 두었음에도 불구하고 무한 호출을 하는 오류로 인해서 각 API에서 해당 부분을 주석처리 했습니다. 만약 제가 작성한 토큰 만료 대응 로직으로 진행한다면 현재 프로젝트에 추가되어 있는 Interceptor 파일을 삭제해야 할 것 같아요. 이 부분에 대해서 의견이 있으시다면 남겨주세요 !! 


**[ 404 Error ]**
(현재 이 부분은 메인만 핸들링이 되어 있기 때문에 MainAPI, MainViewModel, MainVC를 참고하면 됩니다.)
- 엑세스 토큰이 만료되면, 리프레시 토큰을 바탕으로 엑세스 토큰을 갱신하기 위해 AuthAPI를 호출합니다. 이 때 경우의 수는 두가지 입니다.
- 1. 엑세스 토큰 갱신이 성공이라면 -> 갱신된 엑세스 토큰을 저장해서, 이를 header로 보내 다시 API를 호출합니다.
- 2. 엑세스 토큰 갱신이 실패라면 -> 리프레시 토큰 또한 만료된 상황입니다. 그러므로 다시 로그인을 할 수 있도록 로그인 화면으로 이동합니다.


## 🌱 PR Point
- 토큰 만료 시 로직에 대해서 다른 의견이 있다면 남겨주세요 !! 
- 현재 메인화면만 토큰 만료 시 핸들링이 되어 있습니다. 이유는, 크게 두 가지입니다. 다른 부분까지 건들면 코드 변경 사항이 너무 많을 것 같았고, 앱에 들어왔을 때 일단 메인 화면부터 시작이 되기 때문에 일단 메인만 변경해 두었습니다. 하지만, 다른 화면에서도 서버 통신 시마다 토큰이 만료될 수 있기 때문에 로직을 적용해야 하므로 이후에 로직 추가를 진행할 예정입니다. :)



## 📮 관련 이슈
- Resolved: #99 
