### PR TITLE
[Fix] sendingData 분기처리 (#123)

### DIFF
--- a/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
+++ b/WAL/WAL/Screen/History/Controller/HistoryViewController.swift
@@ -56,6 +56,10 @@ final class HistoryViewController: UIViewController {
     weak var resendWalDelegate: ResendWalDelegate?
     weak var refreshDelegate: RefreshDelegate?
     
+    let calendar = Calendar.current
+    let currentDate = Date()
+    var daysCount: Int = 0
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -195,6 +199,10 @@ final class HistoryViewController: UIViewController {
         }
         optionMenu.addAction(closeAction)
         self.present(optionMenu, animated: true)
+    }
+
+    func days(from date: Date) -> Int {
+        return (calendar.dateComponents([.day], from: currentDate, to: date).day ?? 0) + 1
     }
 }
 
@@ -392,13 +400,23 @@ extension HistoryViewController {
                 
                 if let sendingData = historyData.notDoneData {
                     self.sendingData = sendingData
-                    for _ in 0 ..< sendingData.count {
-                        self.selectedIndices.append([-1,-1])
+                    // MARK: if date is later than today
+                    
+                    for index in 0 ..< sendingData.count {
+                        let date = sendingData[index].sendingDate.components(separatedBy:".")
+                        daysCount = days(from: date[0].toDate() ?? currentDate)
+                        print(daysCount)
+                        
+                        if daysCount < 0 {
+                            completeData.append(sendingData[index])
+                        } else {
+                            self.selectedIndices.append([-1,-1])
+                        }
                     }
                 }
                 
                 if let completeData = historyData.doneData {
-                    self.completeData = completeData
+                    self.completeData.append(contentsOf: completeData)
                     for _ in 0 ..< completeData.count {
                         self.selectedIndices.append([-1,-1])
                     }
@@ -431,12 +449,22 @@ extension HistoryViewController {
                 guard let historyData = historyData else { return }
                 if let sendingData = historyData.notDoneData {
                     self.sendingData = sendingData
-                    for _ in 0 ..< sendingData.count {
-                        self.selectedIndices.append([-1,-1])
+                    // MARK: if date is later than today
+                    
+                    for index in 0 ..< sendingData.count {
+                        let date = sendingData[index].sendingDate.components(separatedBy:".")
+                        daysCount = days(from: date[0].toDate() ?? currentDate)
+                        print(daysCount)
+                        
+                        if daysCount < 0 {
+                            completeData.append(sendingData[index])
+                        } else {
+                            self.selectedIndices.append([-1,-1])
+                        }
                     }
                 }
                 if let completeData = historyData.doneData {
-                    self.completeData = completeData
+                    self.completeData.append(contentsOf: completeData)
                     for _ in 0 ..< completeData.count {
                         self.selectedIndices.append([-1,-1])
                     }


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

(수정 전) “보내는 중” 왈소리에서 계산하고 있는 디데이 계산의 로직은 다음과 같습니다:

- 왈소리의 sendingDate를 가져옵니다
- 그 sendingDate를 오늘 날짜와 비교하여 뺄셈을 합니다.
- 뺄셈을 해서 나온 날짜수를 표시합니다.

원래 저의 플랜은 이 부분을 조금 건드려서 코드 한줄로 수정하는거였는데요 문제가 있었습니다.
바로 이 부분의 코드가 TableViewCell쪽에 있다는 것이었습니다. 

왈소리 데이터 전체를 관리하고 있는 sendingData와 completeData 쪽 코드는 viewController에 있거든요. 

그래서 그냥 이쪽 코드를 수정하지 않고 이 코드를 그대로 뷰컨 코드에서 재사용했습니다.

**ViewController**

- 우선 sendingDate를 가져와서 오늘 날짜와 비교하여 디데이를 카운트 하는 코드는 전에 설명된 로직과 같습니다.
- 수정된 점은 **남은 날짜가 0보다 작으면(날짜가 지났지만 푸시알림이 오지 않은 경우) 이를 completeData (전송 완료된 왈소리) 쪽에 넣어줍니다.**
- 남은 날짜가 0보다 크면(푸시알림 대기 중) 원래대로 selectedIndices(접힌 상태 유지를 관리하는 array)에 [-1, -1]를 넣어줍니다. 이부분은 원래 있던 코드입니다.

그리고 completeData 쪽에서 수정된 부분은 다음과 같습니다:

원래는 서버에서 가져오는 completeData를 array에 그대로 넣었지만 이젠 앞에서 디데이가 지나 여기에 append된 왈소리가 있을수도 있기 때문에 append로 수정했습니다.

예.. 그리고 이거 삭제 후에 처리해주는 `getHistoryInfoAfterDelete()` function에서도 똑같이 적용해줘야되기 때문에 뭐… 함수랑 변수들 밖으로 빼서 좀 정리해줬습니다.

프린트 찍어서 정상작동도 확인 해봤는데 그… 문제점은 이제 **제 폰에 너무 푸시알림이 야무지게 와서 에러 처리가 제대로 된건지 확인을 못해봤어요…**

긍까… 푸시알림이 오니까 디데이가 마이너스인게 없음… 

공유끝

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #123 
