### PR TITLE
[Fix] 설정에 재발급 로직 추가 (#122)

### DIFF
--- a/WAL/WAL/Screen/Setting/Controller/SettingAlarmViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SettingAlarmViewController.swift
@@ -171,6 +171,8 @@ extension SettingAlarmViewController {
             case .okay:
                 self.updateButtonStates(data: data)
                 self.previousAlarm = data
+            case .unAuthorized:
+                self.requestRefreshToken(apiType: "get")
             default:
                 self.showToast(message: "Error : \(statusCode)")
             }
@@ -196,9 +198,27 @@ extension SettingAlarmViewController {
                         self.loadingView.hide()
                         self.transition(self, .pop)
                     }
+                case .unAuthorized:
+                    self.requestRefreshToken(apiType: "post")
                 default:
                     self.showToast(message: "Error : \(statusCode)")
                 }
+            }
+        }
+    }
+    
+    private func requestRefreshToken(apiType: String) {
+        AuthAPI.shared.postReissue { [weak self] response, statusCode in
+            guard let _self = self else { return }
+            guard let _statusCode = statusCode else { return }
+            let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
+            switch networkResult {
+            case .okay:
+                apiType == "getAlarm" ? _self.getAlarm() : _self.postAlarm()
+            case .unAuthorized:
+                _self.pushToLoginView()
+            default:
+                break
             }
         }
     }

--- a/WAL/WAL/Screen/Setting/Controller/SettingCategoryViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SettingCategoryViewController.swift
@@ -160,6 +160,8 @@ extension SettingCategoryViewController {
             case .okay:
                 self.updateButtonStates(data: data)
                 self.previousCategory = data
+            case .unAuthorized:
+                self.requestRefreshToken(apiType: "get")
             default:
                 self.showToast(message: "Error : \(statusCode)")
             }
@@ -185,10 +187,28 @@ extension SettingCategoryViewController {
                         self.loadingView.hide()
                         self.transition(self, .pop)
                     }
+                case .unAuthorized:
+                    self.requestRefreshToken(apiType: "post")
                 default:
                     self.showToast(message: "Error : \(statusCode)")
                     return
                 }
+            }
+        }
+    }
+    
+    private func requestRefreshToken(apiType: String) {
+        AuthAPI.shared.postReissue { [weak self] response, statusCode in
+            guard let _self = self else { return }
+            guard let _statusCode = statusCode else { return }
+            let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
+            switch networkResult {
+            case .okay:
+                apiType == "get" ? _self.getCategory() : _self.postCategory()
+            case .unAuthorized:
+                _self.pushToLoginView()
+            default:
+                break
             }
         }
     }

--- a/WAL/WAL/Screen/Setting/Controller/SubController/ResignViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SubController/ResignViewController.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 
+import KakaoSDKAuth
+import KakaoSDKCommon
+import KakaoSDKUser
 import Then
 import WALKit
 
@@ -108,6 +111,17 @@ final class ResignViewController: UIViewController {
 // MARK: - Network
 
 extension ResignViewController {
+    private func kakaoUnlink() {
+        UserApi.shared.unlink {(error) in
+            if let error = error {
+                print("unlink()", error)
+            }
+            else {
+                print("unlink() success.")
+            }
+        }
+    }
+    
     private func postResign() {
         let param = ResignRequest(reasons: reasonData)
         AuthAPI.shared.postResign(param: param) { [weak self] (resignData, statusCode) in
@@ -117,6 +131,7 @@ extension ResignViewController {
             let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
             switch networkResult {
             case .noContent:
+                _self.kakaoUnlink()
                 _self.pushToLoginView()
                 UserDefaultsHelper.standard.removeObject()
             case .unAuthorized:

--- a/WAL/WAL/Screen/Setting/Model/Setting.swift
+++ b/WAL/WAL/Screen/Setting/Model/Setting.swift
@@ -62,7 +62,7 @@ struct SettingData {
         Setting(menu: "왈이 궁금해요"),
         Setting(menu: "공지사항"),
         Setting(menu: "서비스 이용 약관"),
-        Setting(menu: "버전 정보", subMenu: "1.0")
+        Setting(menu: "버전 정보", subMenu: "1.0.0")
     ]
     
     var resignRowData = [


### PR DESCRIPTION
## 🌱 작업한 내용

- 설정에 토큰 만료 재발급 코드 추가했습니다.
- 카카오 로그아웃 시에 카카오 코드 추가했습니다.

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->
- 별개로, 도르마무 이슈를 해결하려고 봤는데, 탈퇴 -> 로그인화면 -> 로그인버튼 클릭 후 왈로 돌아와서 -> todayWal 서버통신이 약 2차례 이뤄지고 실패 후 (당연 실패함 왜냐, 액세스토큰을 탈퇴하면서 지우니까 그러다보니 401 뜨고 만료로직 부름) -> 로그인 서버통신이 그 후 이뤄지고 로긘이 성공합니다.
- 결론적으로 이유를 잘 모르겠음.  

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #122 
