### PR TITLE
[Hotfix] MainViewModel init 시점 및 메인상태 UI 업데이트 로직 수정 (#134)

### DIFF
--- a/WAL/WAL/Resource/Support/AppDelegate.swift
+++ b/WAL/WAL/Resource/Support/AppDelegate.swift
@@ -93,7 +93,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         if userInfo != nil {
             print("푸시 클릭, userinfo 있음")
             if UIApplication.shared.applicationState == .active {
-                let vc = MainViewController(viewModel: .init())
+                let vc = MainViewController()
                 window?.rootViewController?.present(vc, animated: true, completion: nil)
                 
             } else {

--- a/WAL/WAL/Resource/Support/AppDelegate.swift
+++ b/WAL/WAL/Resource/Support/AppDelegate.swift
@@ -93,6 +93,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         if userInfo != nil {
             print("푸시 클릭, userinfo 있음")
             if UIApplication.shared.applicationState == .active {
+                NotificationCenter.default.post(name: NSNotification.Name.enterMain, object: nil)
                 let vc = MainViewController()
                 window?.rootViewController?.present(vc, animated: true, completion: nil)
                 

--- a/WAL/WAL/Resource/Support/SceneDelegate.swift
+++ b/WAL/WAL/Resource/Support/SceneDelegate.swift
@@ -37,9 +37,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func sceneWillResignActive(_ scene: UIScene) { }
     
-    func sceneWillEnterForeground(_ scene: UIScene) {
-        NotificationCenter.default.post(name: NSNotification.Name.enterMain, object: nil)
-    }
+    func sceneWillEnterForeground(_ scene: UIScene) { }
     
     func sceneDidEnterBackground(_ scene: UIScene) { }
     

--- a/WAL/WAL/Resource/Support/SceneDelegate.swift
+++ b/WAL/WAL/Resource/Support/SceneDelegate.swift
@@ -22,7 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let accesstoken = UserDefaultsHelper.standard.accesstoken else { return }
         
         if nickname != Constant.Login.nickname && accesstoken != "" { ///닉네임O, 액세스토큰O -> 자동로그인 -> 메인
-            window?.rootViewController = UINavigationController(rootViewController: MainViewController(viewModel: .init()))
+            window?.rootViewController = UINavigationController(rootViewController: MainViewController())
         } else if nickname == Constant.Login.nickname && accesstoken != "" { ///닉네임X, 액세스토큰O -> 온보딩
             window?.rootViewController = UINavigationController(rootViewController: OnboardingViewController())
         } else { /// 로그인

--- a/WAL/WAL/Screen/Login/Controller/LoginViewController.swift
+++ b/WAL/WAL/Screen/Login/Controller/LoginViewController.swift
@@ -102,10 +102,13 @@ final class LoginViewController: UIViewController {
     
     private func pushToHome() {
         guard let nickname = UserDefaultsHelper.standard.nickname else { return }
+        
         if nickname == Constant.Login.nickname {
             transition(OnboardingViewController(), .presentFullNavigation)
         } else {
-            transition(MainViewController(viewModel: .init()), .presentFullNavigation)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.transition(MainViewController(), .presentFullNavigation)
+            }
         }
     }
     

--- a/WAL/WAL/Screen/Login/Controller/LoginViewController.swift
+++ b/WAL/WAL/Screen/Login/Controller/LoginViewController.swift
@@ -149,7 +149,7 @@ extension LoginViewController {
             UserDefaultsHelper.standard.social = socialType.rawValue
             
             switch networkResult {
-            case .okay:
+            case .okay, .created:
                 self.pushToHome()
             default:
                 self.showToast(message: "Error: \(_statusCode)")

--- a/WAL/WAL/Screen/Main/ViewModel/MainViewModel.swift
+++ b/WAL/WAL/Screen/Main/ViewModel/MainViewModel.swift
@@ -120,7 +120,7 @@ final class MainViewModel {
             
         default:
             if isShownCount == canOpenCount {
-                output.walStatus.accept(isShownCount == output.todayWalCount.value ? .checkedAll : .checkedAvailable)
+                output.walStatus.accept(isShownCount == _todayWalList.count ? .checkedAll : .checkedAvailable)
             } else {
                 output.walStatus.accept(.arrived)
             }
@@ -197,9 +197,8 @@ extension MainViewModel {
             switch networkResult {
             case .okay:
                 guard let _todayWalInfo = mainData?.todayWalInfo else { return }
-                _self.output.todayWal.accept(_todayWalInfo)
-                _self.output.todayWalCount.accept(_todayWalInfo.count)
                 _self.handleWalState(todayWalList: _todayWalInfo)
+                _self.output.todayWal.accept(_todayWalInfo)
             case .unAuthorized:
                 _self.requestRefreshToken(requestType: .todayWal, id: nil)
             default:
@@ -301,7 +300,6 @@ extension MainViewModel {
     
     struct Output {
         let todayWal = PublishRelay<[TodayWal]>()
-        let todayWalCount = BehaviorRelay<Int>(value: 0)
         let subTitle = PublishRelay<String>()
         let walStatus = PublishRelay<WalStatus>()
         let openWal = PublishRelay<Int>()

--- a/WAL/WAL/Screen/Onboarding/Controller/OnboardCompleteViewController.swift
+++ b/WAL/WAL/Screen/Onboarding/Controller/OnboardCompleteViewController.swift
@@ -89,7 +89,7 @@ final class OnboardCompleteViewController: UIViewController {
     // MARK: - @objc
     
     @objc func touchupStartButton() {
-        let viewController = MainViewController(viewModel: .init())
+        let viewController = MainViewController()
         let transition = CATransition()
         transition.duration = 0.2
         transition.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)

--- a/WAL/WAL/Screen/Setting/Controller/SettingAlarmViewController.swift
+++ b/WAL/WAL/Screen/Setting/Controller/SettingAlarmViewController.swift
@@ -214,7 +214,7 @@ extension SettingAlarmViewController {
             let networkResult = NetworkResult(rawValue: _statusCode) ?? .none
             switch networkResult {
             case .okay:
-                apiType == "getAlarm" ? _self.getAlarm() : _self.postAlarm()
+                apiType == "get" ? _self.getAlarm() : _self.postAlarm()
             case .unAuthorized:
                 _self.pushToLoginView()
             default:


### PR DESCRIPTION
오늘의 왈소리 조회 이후 CollectionView 레이아웃 및 각 셀 데이터 업데이트를 하나의 스트림에서 관리하도록 수정

## 🌱 작업한 내용
### 토큰 만료 이후 로그인 화면에서 중복,무한 호출되는 이슈 
- 제가 생각했을 때는 메인화면 VC를 호출하는 시점에서 VM 의존성을 넣어주는데, 그 때 생성 시점에 rxBind가 걸려 있어서 도르마무가 실행되지 않나 .. 라고 의심했습니다. 그래서 일단 VC에서 VM 객체를 갖고 있는 방식으로 수정했어요.
- LoginVC에서 메인화면으로 이동할 때 새롭게 발급받은 헤더를 이용해서 메인을 호출할 수 있도록 하려고 DispatchQueue로 현재 시점에서 0.5초 이후에 화면 전환이 되도록 수정했습니다.

### 메인 화면에서 빈 화면으로 보이는 이슈 
- 메인 화면에서 왈뿡이 캐릭터/왈소리가 보이지 않고 흰 화면으로 보이는 이슈에 대해서는 기존의 방식에서는 왈소리를 GET하고 나서 왈소리, 왈소리 개수, 왈소리 개수에 따른 왈뿡이 상태를 VM에서 API 호출 이후 각각의 output으로 내뱉어서 서로 다른 stream으로 관리되었습니다. 이 때 문제가 있는 것 같아 왈소리/왈소리 개수(-> 하단 컬렉션뷰의 레이아웃 업데이트를 위해 필요) 하나의 스트림에서 관리할 수 있도록 do문으로 넣었어요.
- 다만, 왈뿡이 상태는 하나의 스트림에서 관리할 경우, VC가 비즈니스 로직을 갖고 있어야 하기에 일단 나누어 두었습니다. 만약 같은 이슈가 또 반복된다면 이 부분을 수정해볼게요. 

## 🌱 PR Point
- 코드 보시고 이해가 안되는 부분이 있거나, 다른 부분에서 이슈가 의심된다면 남겨주세요!

## 📮 관련 이슈
- Resolved: #134 
